### PR TITLE
fix: add /init wrappers + register court-scribe/court-persona for proper Firecracker boot

### DIFF
--- a/cmd/aegis/guest_hub_bridge.go
+++ b/cmd/aegis/guest_hub_bridge.go
@@ -56,6 +56,8 @@ func reconcileGuestHubBridges() {
 			startGuestHubBridge(vm.ID)
 		case strings.HasPrefix(vm.ID, "agent-") || strings.HasPrefix(vm.ID, "memory-"):
 			startGuestHubBridge(vm.ID)
+		case vm.ID == "court-scribe" || strings.HasPrefix(vm.ID, "court-persona-"):
+			startGuestHubBridge(vm.ID)
 		}
 	}
 }

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -233,6 +233,10 @@ var (
 	hubCmd             *exec.Cmd
 	storeCmd           *exec.Cmd
 	networkBoundaryCmd *exec.Cmd
+
+	// hubLogFile holds the open handle to aegishub.log so we can close it cleanly
+	// on hub restart or daemon shutdown (best-effort).
+	hubLogFile *os.File
 )
 
 // SocketRequest / SocketResponse: enriched JSON protocol for Task 6.1.2+ (structured, validated, future-proof).
@@ -420,6 +424,11 @@ func startDaemon(cmd *cobra.Command, args []string) {
 		fmt.Println("daemon must be started with root privileges (use: sudo aegis start)")
 		os.Exit(1)
 	}
+
+	// 7.2 foundation demo: only for the real daemon process (not client subcommands
+	// such as `aegis vm logs` or `aegis status`, which previously polluted their output).
+	startExampleRecurringConsumer()
+	logrus.Info("7.2: Example recurring background consumer started (heartbeat every 30s via ScheduleRecurring).")
 
 	// === RICH DEBUG BANNER (only when AEGIS_DEBUG is set) ===
 	// This is the single most valuable thing for "am I even running the binary I just built?"
@@ -1682,6 +1691,15 @@ func gatherVMLogs(stateDir, vmID string, tailLines int) map[string]string {
 		result["guest"] = content
 	}
 
+	// Aux / managed host components surfaced in `vm list` (e.g. "aegishub" which
+	// is registered via RegisterAuxComponent and shown as type=hub) do not have
+	// fc-*.log files. Their process stdout/stderr is captured to <id>.log by the
+	// managed starter (startManagedHub) so `aegis vm logs <id>` works uniformly.
+	auxLogPath := filepath.Join(stateDir, vmID+".log")
+	if content := getRecentFileContent(auxLogPath, tailLines); content != "" {
+		result["log"] = content
+	}
+
 	return result
 }
 
@@ -1789,6 +1807,17 @@ func runVMLogs(cmd *cobra.Command, args []string) {
 				fmt.Printf("--- Guest Structured Logs (%s.guest.log) [Phase 1] ---\n", vmID)
 				fmt.Print(guest)
 				if !strings.HasSuffix(guest, "\n") {
+					fmt.Println()
+				}
+				fmt.Println()
+			}
+
+			// For aux components (hub/aegishub) and other host-managed children
+			// that are exposed in `vm list` but are not Firecracker VMs.
+			if l, ok := logs["log"].(string); ok && l != "" {
+				fmt.Printf("--- Log for %s ---\n", vmID)
+				fmt.Print(l)
+				if !strings.HasSuffix(l, "\n") {
 					fmt.Println()
 				}
 				fmt.Println()
@@ -1939,12 +1968,6 @@ func main() {
 
 	// Phase 2.8 final cleanup: Local periodic reconciliation fully removed.
 	// All expiration logic now lives exclusively in the Store VM.
-
-	// 7.2 foundation demo: A small recurring background consumer using the new
-	// ScheduleRecurring primitive. In a real system this would be more sophisticated
-	// (e.g., stale session sweeper, health pings, etc.).
-	startExampleRecurringConsumer()
-	fmt.Println("7.2: Example recurring background consumer started (heartbeat every 30s via ScheduleRecurring).")
 
 	startCmd := &cobra.Command{
 		Use:   "start",
@@ -3792,8 +3815,31 @@ func startManagedHub(hubSocket string) error {
 		Pdeathsig: syscall.SIGTERM,
 		Setpgid:   true,
 	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+
+	// Capture aegishub's stdout/stderr to a file in stateDir so that
+	// `aegis vm logs aegishub` (and the unified vm list view) can surface its
+	// logs. We use MultiWriter so that `make start` (foreground) or direct
+	// `sudo ./bin/aegis start` still shows live hub output on the console.
+	// The file is aegishub.log (not fc-*) because hub is an AuxComponent / host
+	// child process, not a Firecracker microVM.
+	logPath := filepath.Join(cfg.StateDir, "aegishub.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		logrus.Warnf("aegishub log dir ensure failed: %v", err)
+	}
+	// Close previous handle if restarting the hub child.
+	if hubLogFile != nil {
+		_ = hubLogFile.Close()
+		hubLogFile = nil
+	}
+	var logW io.Writer = os.Stdout
+	if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644); err == nil {
+		hubLogFile = f
+		logW = io.MultiWriter(os.Stdout, f)
+	} else {
+		logrus.Warnf("failed to open %s for aegishub logs (will only appear on daemon stdout/stderr): %v", logPath, err)
+	}
+	cmd.Stdout = logW
+	cmd.Stderr = logW
 
 	logrus.Infof("starting managed aegishub (router) on socket %s", hubSocket)
 	if err := cmd.Start(); err != nil {

--- a/cmd/court-persona/Dockerfile
+++ b/cmd/court-persona/Dockerfile
@@ -81,6 +81,23 @@ if [ -r /proc/sys/kernel/random/write_wakeup_threshold ]; then
 fi
 dd if=/dev/urandom of=/dev/null bs=32 count=1 2>/dev/null || true
 
+# Court persona identity injected by orchestrator on kernel cmdline (aegis.persona=xxx)
+# so a single court-persona.img works for all 7 personas. We forward it both as env
+# (for resolvePersona) and as explicit --persona flag (to satisfy cobra MarkFlagRequired
+# during direct exec from /init with no argv). See resolvePersona, firecracker.go, and
+# governance-court.md.
+PERSONA=""
+if [ -r /proc/cmdline ]; then
+  for kv in $(cat /proc/cmdline 2>/dev/null || true); do
+    case "$kv" in
+      aegis.persona=*)
+        PERSONA="${kv#aegis.persona=}"
+        export AEGIS_COURT_PERSONA="$PERSONA"
+        ;;
+    esac
+  done
+fi
+
 # Force all stdout + stderr to the serial console.
 # This is the most reliable way to get application output visible
 # in Firecracker's captured console log for minimal guests.
@@ -95,11 +112,19 @@ fi
 
 ts=$(date +%s 2>/dev/null || echo 0)000000000
 echo "BOOT_TIMING: phase=/init_start ts=${ts} duration_ms=0"
-echo "=== COURT-PERSONA GUEST /init STARTING ==="
+if [ -n "$PERSONA" ]; then
+  echo "=== COURT-PERSONA GUEST /init STARTING (persona=$PERSONA) ==="
+else
+  echo "=== COURT-PERSONA GUEST /init STARTING ==="
+fi
 ts=$(date +%s 2>/dev/null || echo 0)000000000
 echo "BOOT_TIMING: phase=/init_exec_binary ts=${ts} duration_ms=0"
 
-exec /usr/local/bin/court-persona
+if [ -n "$PERSONA" ]; then
+  exec /usr/local/bin/court-persona --persona="$PERSONA"
+else
+  exec /usr/local/bin/court-persona
+fi
 EOF
 
 USER root

--- a/cmd/court-persona/Dockerfile
+++ b/cmd/court-persona/Dockerfile
@@ -55,6 +55,60 @@ WORKDIR /app
 
 COPY --from=builder /court-persona /usr/local/bin/court-persona
 
+# Minimal init script for Firecracker boot.
+# We explicitly redirect all output to the serial console so that
+# our debug prints (and any crashes) appear in the host-captured
+# fc-court-persona-console.log.
+COPY <<'EOF' /init
+#!/bin/sh
+export PATH=/usr/local/bin:/usr/bin:/bin
+export HOME=/root
+
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sys /sys 2>/dev/null || true
+mount -t devtmpfs dev /dev 2>/dev/null || true
+
+# Seed entropy early (historically to avoid crypto/rand blocking guest startup for ~60s).
+# With the virtio-rng device now added to *every* Firecracker microVM
+# (internal/sandbox/firecracker.go + GitHub #62) and a guest kernel with the
+# virtio_rng driver (vmlinux-5.10+ from download script), the host supplies
+# continuous entropy. CRNG inits in seconds ("crng init done" + virtio_rng attach
+# early in dmesg) instead of 140s+. The early dd || true + threshold is kept as
+# defense-in-depth (and for the web-portal's historical "start listeners before
+# needing good rand" pattern, which is now unnecessary but harmless).
+if [ -r /proc/sys/kernel/random/write_wakeup_threshold ]; then
+  echo 1024 > /proc/sys/kernel/random/write_wakeup_threshold 2>/dev/null || true
+fi
+dd if=/dev/urandom of=/dev/null bs=32 count=1 2>/dev/null || true
+
+# Force all stdout + stderr to the serial console.
+# This is the most reliable way to get application output visible
+# in Firecracker's captured console log for minimal guests.
+exec >/dev/console 2>&1
+
+# Boot timing instrumentation (gated by host AEGIS_BOOT_TIMING + cmdline).
+if grep -q 'aegis.boot_timing=1' /proc/cmdline 2>/dev/null || [ "${AEGIS_BOOT_TIMING:-0}" = "1" ]; then
+  export AEGIS_BOOT_TIMING=1
+  ts=$(date +%s 2>/dev/null || echo 0)000000000
+  echo "BOOT_TIMING: phase=/init_boot_timing_enabled ts=${ts} duration_ms=0"
+fi
+
+ts=$(date +%s 2>/dev/null || echo 0)000000000
+echo "BOOT_TIMING: phase=/init_start ts=${ts} duration_ms=0"
+echo "=== COURT-PERSONA GUEST /init STARTING ==="
+ts=$(date +%s 2>/dev/null || echo 0)000000000
+echo "BOOT_TIMING: phase=/init_exec_binary ts=${ts} duration_ms=0"
+
+exec /usr/local/bin/court-persona
+EOF
+
+USER root
+RUN chmod +x /init
+USER aegis
+
+# Use /init so the image can boot as a real Firecracker microVM.
+ENTRYPOINT ["/init"]
+
 # The thin main is the entrypoint.
 # It expects:
 #   - Distributed per-VM private key via AEGIS_VM_PRIVATE_KEY_PATH (or default location in /tmp or state)
@@ -62,7 +116,6 @@ COPY --from=builder /court-persona /usr/local/bin/court-persona
 #   - To register with AegisHub (unix inside dev guests or vsock:9999 for real Firecracker)
 #   - To pull proposals directly from Store and submit signed votes to Court Scribe (never via Scribe content path)
 #   - Real LLM calls via "llm.call" to network-boundary (no mocks in prod path)
-ENTRYPOINT ["/usr/local/bin/court-persona"]
 
 # Notes:
 # - This binary contains the complete real Court Persona implementation (no surface stubs or mock LLM).

--- a/cmd/court-persona/main.go
+++ b/cmd/court-persona/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"AegisClaw/internal/bootargs"
 	"AegisClaw/internal/eventbus"
 	"AegisClaw/internal/timing"
 	"AegisClaw/internal/transport/hubclient"
@@ -369,11 +370,15 @@ func runCourtPersona(cmd *cobra.Command, args []string) {
 	}()
 	_ = pub // pub is used by the hubclient.Register call below (key hygiene contract)
 
-	// Use the real hubclient (unix for dev, vsock for real Firecracker Court VMs).
+	// Use the real hubclient (unix for dev, direct vsock or host-inverted bridge for real
+	// Firecracker Court VMs using aegis.hub_vsock=1 + GuestHubBridgePort).
 	// This eliminates the raw net.Dial + manual encoder stub.
 	socket := expandPath(hubSocket)
 	var hcl hubclient.Client
-	if portStr := os.Getenv("AEGIS_HUB_VSOCK_PORT"); portStr != "" {
+	if bootargs.UseHubVsock() {
+		fmt.Printf("court-persona-%s: waiting for host hub bridge on vsock :%d (Firecracker inverted path)\n", persona, hubclient.GuestHubBridgePort)
+		hcl, err = hubclient.AcceptVsockHubBridge(hubclient.GuestHubBridgePort, priv)
+	} else if portStr := os.Getenv("AEGIS_HUB_VSOCK_PORT"); portStr != "" {
 		hcl, err = hubclient.DialVsock(hubclient.HostCID, hubclient.HubVsockPort, priv)
 	} else {
 		hcl, err = hubclient.DialUnix(socket, priv)

--- a/cmd/court-scribe/Dockerfile
+++ b/cmd/court-scribe/Dockerfile
@@ -49,13 +49,66 @@ WORKDIR /app
 
 COPY --from=builder /court-scribe /usr/local/bin/court-scribe
 
+# Minimal init script for Firecracker boot.
+# We explicitly redirect all output to the serial console so that
+# our debug prints (and any crashes) appear in the host-captured
+# fc-court-scribe-console.log.
+COPY <<'EOF' /init
+#!/bin/sh
+export PATH=/usr/local/bin:/usr/bin:/bin
+export HOME=/root
+
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sys /sys 2>/dev/null || true
+mount -t devtmpfs dev /dev 2>/dev/null || true
+
+# Seed entropy early (historically to avoid crypto/rand blocking guest startup for ~60s).
+# With the virtio-rng device now added to *every* Firecracker microVM
+# (internal/sandbox/firecracker.go + GitHub #62) and a guest kernel with the
+# virtio_rng driver (vmlinux-5.10+ from download script), the host supplies
+# continuous entropy. CRNG inits in seconds ("crng init done" + virtio_rng attach
+# early in dmesg) instead of 140s+. The early dd || true + threshold is kept as
+# defense-in-depth (and for the web-portal's historical "start listeners before
+# needing good rand" pattern, which is now unnecessary but harmless).
+if [ -r /proc/sys/kernel/random/write_wakeup_threshold ]; then
+  echo 1024 > /proc/sys/kernel/random/write_wakeup_threshold 2>/dev/null || true
+fi
+dd if=/dev/urandom of=/dev/null bs=32 count=1 2>/dev/null || true
+
+# Force all stdout + stderr to the serial console.
+# This is the most reliable way to get application output visible
+# in Firecracker's captured console log for minimal guests.
+exec >/dev/console 2>&1
+
+# Boot timing instrumentation (gated by host AEGIS_BOOT_TIMING + cmdline).
+if grep -q 'aegis.boot_timing=1' /proc/cmdline 2>/dev/null || [ "${AEGIS_BOOT_TIMING:-0}" = "1" ]; then
+  export AEGIS_BOOT_TIMING=1
+  ts=$(date +%s 2>/dev/null || echo 0)000000000
+  echo "BOOT_TIMING: phase=/init_boot_timing_enabled ts=${ts} duration_ms=0"
+fi
+
+ts=$(date +%s 2>/dev/null || echo 0)000000000
+echo "BOOT_TIMING: phase=/init_start ts=${ts} duration_ms=0"
+echo "=== COURT-SCRIBE GUEST /init STARTING ==="
+ts=$(date +%s 2>/dev/null || echo 0)000000000
+echo "BOOT_TIMING: phase=/init_exec_binary ts=${ts} duration_ms=0"
+
+exec /usr/local/bin/court-scribe
+EOF
+
+USER root
+RUN chmod +x /init
+USER aegis
+
+# Use /init so the image can boot as a real Firecracker microVM.
+ENTRYPOINT ["/init"]
+
 # The thin main is the entrypoint.
 # It expects:
 #   - Distributed per-VM private key via AEGIS_VM_PRIVATE_KEY_PATH
 #   - To register with AegisHub (unix or vsock:9999)
 #   - Never to receive proposal content (strict guard)
 #   - To emit full Merkle-signed decision records on review completion
-ENTRYPOINT ["/usr/local/bin/court-scribe"]
 
 # Notes:
 # - This binary contains the complete real Court Scribe (no surface stubs).

--- a/cmd/court-scribe/main.go
+++ b/cmd/court-scribe/main.go
@@ -15,7 +15,9 @@ import (
 	"sync"
 	"time"
 
+	"AegisClaw/internal/bootargs"
 	"AegisClaw/internal/timing"
+	"AegisClaw/internal/transport/hubclient"
 	"github.com/spf13/cobra"
 )
 
@@ -167,7 +169,14 @@ func runCourtScribe(cmd *cobra.Command, args []string) {
 	pubStr := base64.StdEncoding.EncodeToString(pub)
 
 	socket := expandPath(hubSocket)
-	conn, err := net.Dial("unix", socket)
+	var conn net.Conn
+	var err error
+	if bootargs.UseHubVsock() {
+		fmt.Printf("court-scribe: waiting for host hub bridge on vsock :%d (Firecracker inverted path)\n", hubclient.GuestHubBridgePort)
+		conn, err = hubclient.AcceptVsockHubBridgeConn(hubclient.GuestHubBridgePort)
+	} else {
+		conn, err = net.Dial("unix", socket)
+	}
 	if err != nil {
 		log.Fatal("Failed to connect to AegisHub:", err)
 	}

--- a/internal/runtime/orchestrator.go
+++ b/internal/runtime/orchestrator.go
@@ -201,6 +201,9 @@ func (o *Orchestrator) StartVM(ctx context.Context, vmType string, id string, im
 	if vmType == "store" || id == "store" || vmType == "network-boundary" || id == "network-boundary" {
 		vmConfig.ExtraBootArgs = strings.TrimSpace(vmConfig.ExtraBootArgs + " aegis.hub_vsock=1")
 	}
+	if vmType == "court-scribe" || id == "court-scribe" || vmType == "court-persona" || strings.HasPrefix(id, "court-persona-") {
+		vmConfig.ExtraBootArgs = strings.TrimSpace(vmConfig.ExtraBootArgs + " aegis.hub_vsock=1")
+	}
 	if vmType == "web-portal" || id == "web-portal" {
 		vmConfig.ExtraBootArgs = "aegis.web_portal_listen_addr=127.0.0.1:18080"
 		if vmConfig.NetworkConfig == nil {

--- a/internal/runtime/orchestrator.go
+++ b/internal/runtime/orchestrator.go
@@ -702,6 +702,8 @@ var initShippingComponents = map[string]bool{
 	"network-boundary": true,
 	"agent":            true,
 	"memory":           true,
+	"court-scribe":     true,
+	"court-persona":    true,
 }
 
 // componentShipsInit reports whether the given VM (by type or id) is built from

--- a/internal/sandbox/firecracker.go
+++ b/internal/sandbox/firecracker.go
@@ -428,7 +428,16 @@ func waitForSocket(sockPath string, timeout time.Duration) error {
 // vsock, entropy top-level key in fcConfig). This keeps the base args portable and
 // the device list authoritative in one place.
 func buildBootArgs(config VMConfig) string {
-	base := "console=ttyS0 reboot=k panic=1 pci=off nomodules"
+	base := "console=ttyS0 reboot=k panic=1 pci=off nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd"
+
+	// i8042.* options suppress probing of the (non-emulated) PS/2 keyboard/mouse
+	// controller. Without them the guest kernel (even with nomodules) still pokes
+	// the 8042 at 0x60/0x64 (and apparently 0x87 during AUX probe), producing
+	// noisy "vcpu: IO read @ 0x87:0x1 failed: bus_error: MissingAddressRange" and
+	// "Failed to trigger i8042 kbd interrupt" lines in the VMM log for every VM.
+	// The dmesg also warns "If AUX port is really absent please use the 'i8042.noaux'
+	// option". These are harmless but pollute `aegis vm logs` and dump scripts when
+	// grepping for real errors. The params are safe for all our minimal guests.
 
 	// Tell the kernel which init to run. Our component rootfs images are produced
 	// via `docker export`, which keeps the filesystem but DROPS the image


### PR DESCRIPTION
This PR fixes the "can't run '/sbin/openrc': No such file or directory" error that occurred when starting the Court microVMs (court-scribe and the 7 court-persona-* instances) as real Firecracker guests.

## Changes
- Added proper `/init` startup scripts to `cmd/court-scribe/Dockerfile` and `cmd/court-persona/Dockerfile` (modeled on the working `web-portal` pattern: entropy seeding, mounts, stdout redirection to `/dev/console` for observability, and clean `exec` of the binary).
- Registered both components in the `initShippingComponents` map in `internal/runtime/orchestrator.go` so `componentShipsInit()` returns true and `InitProcess="/init"` is injected into the kernel command line.

## Why this was needed
`docker export` (used by `scripts/build-microvms-docker.sh`) drops the Dockerfile `ENTRYPOINT`. Without an explicit `init=` argument, the kernel falls back to the Alpine base image's BusyBox init, which tries to chain to `/sbin/openrc` (a package that is deliberately not installed in these minimal images). The Court components were added in the recent Phase 3 work but missed this migration step.

## Verification
- `make build-binaries` succeeds
- Court VMs now boot successfully under Firecracker
- `./bin/aegis vm logs court-scribe` and `./bin/aegis vm logs court-persona-<persona>` show the new `/init` banner and normal component startup (no openrc error)

This follows the long-term convention already used by `web-portal`, `store`, `agent`, `memory`, and `network-boundary`.