### PR TITLE
docs(specs): introduce STOMP topic subscriptions for web portal real-time updates

### DIFF
--- a/docs/specs/event-system.md
+++ b/docs/specs/event-system.md
@@ -37,6 +37,7 @@ AegisClaw uses a **lightweight, AegisHub-mediated Event System** instead of a fu
 - Safe Mode trigger → broadcast to all components
 - Background task completion → update UI and monitoring
 - Scheduled tasks (daily report, etc.)
+- Web portal real-time UI updates (overview stats, per-conversation deltas) via efficient topic subscriptions (see STOMP section)
 
 ## Implementation Notes
 
@@ -45,21 +46,51 @@ AegisClaw uses a **lightweight, AegisHub-mediated Event System** instead of a fu
 - Events carry `trace_id` for correlation
 - Rate limiting and authorization enforced by AegisHub
 
+## STOMP Topic Subscriptions for Presentation Layer
+
+To relieve unnecessary data transfer and resource usage (network to browser, portal CPU for filtering/bundling, upstream event fan-out), the web portal exposes **STOMP over WebSocket** as the preferred mechanism for fine-grained, topic-based pub/sub from browser clients.
+
+The web portal acts as a **trusted STOMP gateway** (presentation-only component, all traffic still mediated by Host Daemon reverse proxy per `web-portal-vm.md`):
+
+- Browser clients (embedded JS) use a lightweight STOMP-over-WS client (self-contained, no external deps) to `CONNECT` to the portal's STOMP endpoint (e.g. `/stomp` or WS upgrade on existing), `SUBSCRIBE` to topics, receive `MESSAGE` frames with JSON payloads, and `UNSUBSCRIBE` when leaving a view or closing tab.
+- **Topic naming** (STOMP destination convention):
+  - `/topic/overview.stats` — system stats, running microVMs/workers, pending approvals, resource usage, host load. Primary feed for Overview screen stat cards and tables. Replaces or supplements the global SSE ticker bundles.
+  - `/topic/conversation.{sessionId}.updates` — incremental message content_deltas, thought_deltas, tool_events, status changes for a specific chat session. Enables per-conversation streaming with minimal overhead (no global broadcast to all clients).
+  - `/topic/approvals.pending` — updates to the pending approvals list and decisions.
+  - `/topic/canvas.events` (or finer `/topic/worker.{id}.updates`, `/topic/tool.{callId}.events`) — for live Canvas/agent monitoring views.
+- On browser `SUBSCRIBE`, the portal translates (where cross-component coordination is needed) to internal `event.subscribe` calls via the trusted vsock bridge, so AegisHub routes relevant publishes. Local subscriber management in the portal handles efficient in-process fan-out for STOMP sessions.
+- Internal publishes (orchestrator, chat system, Court, skill deploy, etc.) are mapped by the portal STOMP handler to only active matching topic subscribers. MESSAGE payloads preserve existing delta/cursor patterns, trace_ids, and JSON shapes from event buffers.
+- **Benefits**:
+  - Reduced network transfer: clients receive only subscribed topics (no irrelevant bundles or global ticker noise).
+  - Lower compute: portal avoids per-client filtering of a single broad stream; AegisHub/event routing is more targeted.
+  - Explicit lifecycle: `UNSUBSCRIBE` on navigation matches user intent and prevents stale connections/subscriptions.
+  - Better multi-view / multi-tab support (different tabs subscribe to different subsets).
+- STOMP features: heartbeats (keepalive), receipts (reliability for critical updates), error frames. Implement minimal STOMP 1.2 subset in Go (or small audited helper) to keep TCB and attack surface minimal.
+- **Transition & coexistence**: Existing global SSE `/events` (with cursors) and chat hybrid streaming remain during migration for compatibility and E2E stability. New or migrated flows (Overview stats, per-session chat) adopt STOMP topics. The current `ToolEventBuffer`/`ThoughtEventBuffer` and contract tests extend naturally to STOMP MESSAGE payloads.
+- **Security & constraints**: No new privileged code or external broker. All STOMP traffic stays inside the trusted portal VM sandbox and Host proxy. AegisHub ACLs, signing, and audit trail continue to apply to underlying events. Rate limiting and frame validation at STOMP layer as defence-in-depth.
+
+This extension keeps the event system as the single source of truth while giving the presentation layer an efficient pub/sub surface aligned with the isolation and minimalism principles.
+
 ## Related Documents
+
 - `../aegishub.md` — Central mediator for all events
 - `../store-vm.md` — Persistent timer storage
+- `../web-portal.md` — STOMP gateway implementation and topic usage in UI
 - `../skill-discovery.md`
 - `../safe-mode.md`
 - `../builder-security-gates.md`
 
 ## Implementation Status (Phase 7.2)
+
 - In-process Bus with timers, approval queues, PublishPrivileged + security.Manager signing hook.
 - Concrete publishers: orchestrator (vm.started/stopped), Court personas (court.decision.made).
 - Consumers: agent reacts to approval.decision; dynamic skill index refresh.
 - All privileged events have Merkle-style signing path available.
+- **STOMP gateway extension planned** for web portal real-time efficiency (this spec).
 
 ## Traceability
 **Driven by:**
 - Need for coordinated signals without high complexity
 - Lessons from previous `internal/eventbus`
 - Multi-agent coordination and background tasks (User Journeys #3, #5, #8)
+- Requirement to reduce data transfer and compute for real-time UI updates while preserving paranoid isolation model

--- a/docs/specs/web-portal.md
+++ b/docs/specs/web-portal.md
@@ -10,13 +10,13 @@ It is **presentation-only**: no business logic, no persistent state, no secrets.
 ## Current Architecture & Runtime (Implementation)
 - **Entry**: `cmd/aegisportal/main.go` — mounts minimal FS, listens vsock:18080, creates `dashboard.Server` with `portalAPIClient` that dials host bridge (vsock port 1030).
 - **Core**: `internal/dashboard/server.go` (~3388 LOC) — pure `html/template` + embedded CSS/JS, `http.ServeMux`, `APIClient` abstraction.
-  - Real-time: SSE at `/events` (1s ticker + per-event cursors for tools/workers); special streaming for chat (`/chat/send?stream=1` uses progressive deltas + `chat.stream_progress`, tool/thought events).
+  - Real-time: evolving from global SSE `/events` (1s ticker + per-event cursors) + chat hybrid streaming to **STOMP-over-WebSocket topic subscriptions** for efficient, view-specific updates (detailed in new STOMP section below); existing SSE/chat paths retained for transition compatibility.
   - Bridge actions are dispatched via `apiSrv.CallDirect` (some trusted per `isTrustedPortalBridgeAction`).
 - **Handlers present** (many wired in `daemon_handlers_extended.go`, git/workspace in `handlers_git.go`, PRs in `dashboard_pr_handlers.go`, events in `tool_events.go`/`thought_events.go`):
   - Core UI + chat + approvals + memory + workers + sandboxes + skills/proposals + async + audit + settings.
   - Phase 2+: Source browser (`git.browse`/`git.branches`), workspace list/edit/read, git history/diff, PR list/detail.
-- **Data flow**: Browser → Portal VM (HTTP) → vsock bridge → Host API (direct or ControlPlaneProxy → AegisHub → backends like Store/Agent VMs).
-- **Styling/JS**: Self-contained GitHub-inspired dark theme. Heavy client-side Markdown renderer + streaming logic for chat/Canvas. No CDNs.
+- **Data flow**: Browser → Portal VM (HTTP + WebSocket/STOMP) → vsock bridge → Host API (direct or ControlPlaneProxy → AegisHub → backends like Store/Agent VMs).
+- **Styling/JS**: Self-contained GitHub-inspired dark theme. Heavy client-side Markdown renderer + streaming logic for chat/Canvas. No CDNs. STOMP client (lightweight self-contained) added for real-time topics.
 
 **Note on completeness**: UI scaffolding and many full experiences (chat, Canvas, overview, approvals, proposal detail, source/workspace) are implemented in the portal. Some backend action registrations (e.g., full `git.*`, `workspace.*`, `dashboard.*` legacy) and `/api/*` REST surface are partial or delegated via proxy/hub; fallbacks or errors surface clearly. See also `phase4-pr-system.md` and `issue-35.md` for SDLC vision that drove many of these features.
 
@@ -37,19 +37,19 @@ It is **presentation-only**: no business logic, no persistent state, no secrets.
 **Typography**: `system-ui, -apple-system, sans-serif`; monospace `ui-monospace, SFMono-Regular, Menlo, Consolas...`
 
 **Components**:
-- Top `<nav>`: logo (🛡️ AegisClaw), links, live SSE status (● live / disconnected).
+- Top `<nav>`: logo (🛡️ AegisClaw), links, live status (SSE or STOMP connection indicator).
 - `<main>` with `<h1>`, `.section` cards (header + content, hover rows, overflow hidden).
 - Tables with badges (dynamic `badge-{{status}}`).
 - Forms for decisions (approve/danger buttons), search, chat input.
 - Chat: fixed layout, sidebar sessions, bubbles (user right blue, assistant left), `.markdown-bubble` full parser (headings, lists, tasks, tables, code, blockquotes, hr, links sanitized), `.thought-log`, `.tool-log`, model pills, streaming deltas.
-- Canvas: grid of agent cards, tool feed, ascii interaction graph, live log — all SSE-updated.
+- Canvas: grid of agent cards, tool feed, ascii interaction graph, live log — updated via STOMP topics or SSE.
 - Responsive (mobile adjustments for chat sidebar/bubbles).
 - Empty states, muted text, disclosure `<details>` for tools.
 
 **Navigation (exact current)**:
 Overview • Canvas • Chat • Agents • Skills • PRs • Source • Git • Workspace • Async Hub • Memory • Approvals • Audit • Settings
 
-(Header also shows live dot via SSEScript.)
+(Header also shows live connection status via real-time script.)
 
 This replaces the older wireframe nav (Conversations/Teams/Court/Monitoring).
 
@@ -57,17 +57,16 @@ This replaces the older wireframe nav (Conversations/Teams/Court/Monitoring).
 See also legacy wireframes in `web-portal-screens.md` for historical concepts; below reflects actual rendered templates + JS.
 
 ### 1. Overview (`/`)
-Stat cards grid (Running MicroVMs, Active Workers, Pending Approvals, Active Timers, Memory Entries, vCPUs/Mem allocated, Host RAM bar + Load). Tables for Running VMs (with RSS/CPU), Active Workers, Pending Approvals summary. Fetches system.stats, sandbox resources, etc. Quick links to other areas.
+Stat cards grid (Running MicroVMs, Active Workers, Pending Approvals, Active Timers, Memory Entries, vCPUs/Mem allocated, Host RAM bar + Load). Tables for Running VMs (with RSS/CPU), Active Workers, Pending Approvals summary. Initial fetch via `system.stats` etc.; **live updates via STOMP subscription to `/topic/overview.stats`** (preferred) or existing SSE bundles. Quick links to other areas.
 
 ### 2. Canvas (`/canvas`) — Live Visual Workspace
-Agent cards grid (from workers), tool-call feed per agent, "Agent Interaction Graph" (text), Live Tool-Call Log. Uses initial data + SSE (`tool_start`/`tool_end`, `worker_start`). Real-time collaborative monitoring view. (Implements monitoring + team concepts from journeys #5/#8.)
+Agent cards grid (from workers), tool-call feed per agent, "Agent Interaction Graph" (text), Live Tool-Call Log. Uses initial data + **STOMP topics** (e.g. `/topic/canvas.events` or per-worker/tool) or SSE (`tool_start`/`tool_end`, `worker_start`). Real-time collaborative monitoring view. (Implements monitoring + team concepts from journeys #5/#8.)
 
 ### 3. Chat (`/chat`) — Full Interactive Sessions
 Sidebar: sessions list + New button (server-backed via Store VM through thin `/api/chat/sessions`, `/api/chat/history`, and `/api/chat/sessions/{id}` bridge actions; the previous `aegisclaw.chat.sessions.v1` localStorage silo has been removed so conversations are visible across browsers/devices). Chat turns are sent via `/chat/send` → `chat.message` through the agent chat system; the portal only forwards messages and persists the session thread back to Store.
 Main: message stream (user/assistant/error bubbles), rich input textarea.
 - Full client Markdown (headings 1-3, task lists [x], ul/ol, tables with align, code blocks/fences, inline code, **bold**, *em*, ~~s~~, blockquotes, hr, sanitized links).
-- Streaming: `/chat/send` with Accept SSE or `?stream=1` → progressive `content_delta`/`thought_delta`, tool/thought events, progress via `chat.stream_progress`.
-- Logs: `.tool-log` (calls, payload, duration, status), `.thought-log` (phases: model_thinking etc, model/tool, timestamps).
+- **Streaming**: `/chat/send` with Accept SSE or `?stream=1` → progressive `content_delta`/`thought_delta`, tool/thought events (hybrid during transition); **preferred path migrates to per-session STOMP topic `/topic/conversation.{sessionId}.updates`** for targeted, low-overhead deltas without global fan-out. Logs: `.tool-log` (calls, payload, duration, status), `.thought-log` (phases: model_thinking etc, model/tool, timestamps).
 - Model pills, typing, error handling, history carry-over.
 - Supports sessions, history.
 
@@ -108,7 +107,7 @@ Active Timers table + Recent Signals table. (event.timers/signals)
 Search form + list/search results (key, value truncated, ttl_tier). `memory.list` / `memory.search`.
 
 ### 13. Approvals (`/approvals?all=1`, POST `/approvals/decide`)
-Pending (or all) approvals list with risk badges, description, decide form (approve/reject + optional reason). Calls `event.approvals.list` + `.decide`. Core governance UI.
+Pending (or all) approvals list with risk badges, description, decide form (approve/reject + optional reason). Calls `event.approvals.list` + `.decide`. Core governance UI. **Live updates via STOMP `/topic/approvals.pending`.**
 
 ### 14. Audit (`/audit`)
 Merkle log info + CLI commands to inspect/verify. (Full explorer future.)
@@ -116,12 +115,54 @@ Merkle log info + CLI commands to inspect/verify. (Full explorer future.)
 ### 15. Settings (`/settings`)
 Config file location, key settings table (structured output, memory TTL/PII, quotas, dashboard addr). Privacy/PII redaction section + GDPR note.
 
-Additional: `/health` (ok), SSE shared, error pages, truncation helpers, fmt helpers.
+Additional: `/health` (ok), real-time endpoints (SSE + STOMP), error pages, truncation helpers, fmt helpers.
 
 ## Real-time & Streaming
-- Global SSE `/events`: heartbeat + update bundles (active_workers, pending_approvals, tool_events, thought_events, sessions). Emits granular `tool_start`/`tool_end`, `worker_start` for Canvas.
-- Chat streaming: hybrid (background call + ticker polling events/progress, emit deltas to avoid full re-renders). Suppresses in-flight structured JSON/fences during stream.
-- Event buffers (`ToolEventBuffer`, `ThoughtEventBuffer`) with contract tests in `portal_contract_test.go` (exact JSON shape for id, timestamp, tool, phase, success, duration_ms, etc.).
+- Global SSE `/events`: heartbeat + update bundles (active_workers, pending_approvals, tool_events, thought_events, sessions). Emits granular `tool_start`/`tool_end`, `worker_start` for Canvas. **Being supplemented/replaced by STOMP topic subscriptions for targeted delivery.**
+- Chat streaming: hybrid (background call + ticker polling events/progress, emit deltas to avoid full re-renders). Suppresses in-flight structured JSON/fences during stream. **Migrating to per-conversation STOMP topic for efficiency.**
+- Event buffers (`ToolEventBuffer`, `ThoughtEventBuffer`) with contract tests in `portal_contract_test.go` (exact JSON shape for id, timestamp, tool, phase, success, duration_ms, etc.). These extend to STOMP `MESSAGE` payloads.
+
+## STOMP Topic Subscriptions (New Real-Time Mechanism)
+
+**Rationale**: The current global SSE approach (single ticker pushing bundles to all connected clients) is functional but indiscriminate. As event volume grows (tool calls, thoughts, state changes, multi-agent activity), it transfers and processes more data than necessary. STOMP topic subscriptions allow the browser to declare exactly what it needs and receive only relevant updates, directly reducing network transfer and portal compute while improving responsiveness for different views.
+
+**Architecture**:
+- Portal Go server adds WebSocket handler supporting STOMP frame protocol (minimal 1.2 subset: CONNECT, SUBSCRIBE, UNSUBSCRIBE, MESSAGE, RECEIPT, ERROR, heartbeats). Kept lightweight and self-contained to preserve minimal TCB.
+- STOMP endpoint exposed alongside HTTP (WS upgrade supported by Host Daemon reverse proxy — see recent networking readiness work in `web-portal-vm.md`).
+- Client JS (embedded): lightweight STOMP client connects on dashboard load or view mount, subscribes to topics relevant to current screen, renders incoming MESSAGE frames (reusing existing delta/Markdown rendering logic), unsubscribes on navigation or visibility change.
+- Server-side subscriber management: map of topic → active STOMP sessions. On relevant internal event receipt (via bridge or event callbacks), route only to matching subscribers as STOMP MESSAGE frames. Translation layer maps internal event names/payloads to topic destinations.
+- Integration with existing bridge: STOMP SUBSCRIBE can trigger `event.subscribe` calls for cross-VM coordination; most UI updates are local to portal's knowledge of backend state.
+
+**Initial Topics** (expand as needed):
+- `/topic/overview.stats` for Overview screen live stat cards/tables.
+- `/topic/conversation.{sessionId}.updates` for Chat per-session streaming (content, thoughts, tools).
+- `/topic/approvals.pending` for Approvals list.
+- `/topic/canvas.events` (and granular variants) for Canvas live feeds.
+
+**Client Lifecycle**:
+- Mount/view enter: CONNECT (if needed) + SUBSCRIBE to screen-specific topics.
+- Receive MESSAGE → update DOM (append deltas, update badges, etc.) with existing sanitization/rendering.
+- Navigate away / tab hidden: UNSUBSCRIBE (and DISCONNECT if last).
+- Reconnect + resubscribe on connection loss with backoff.
+
+**Performance Wins**:
+- Network: only subscribed data crosses the wire to browser (no global bundles or ignored events).
+- Compute (portal): no per-client filtering or unnecessary serialisation; targeted fan-out.
+- Upstream: fewer wasted bridge calls or event processings for uninterested clients.
+- Scales better with concurrent users/tabs and higher event rates.
+
+**Migration**:
+- Phase in: Overview and one conversation topic first. Keep SSE paths live and tested.
+- E2E/Contract: extend `portal_contract_test.go` and Playwright suites to cover STOMP connect/sub/unsub flows, message delivery, and absence of irrelevant updates.
+- Fallback: if STOMP unavailable, degrade to existing SSE gracefully.
+
+**Non-Goals / Constraints**:
+- No external message broker or new VM.
+- Portal remains strictly presentation-only.
+- All real-time traffic proxied and mediated; no direct browser-to-AegisHub or browser-to-agent paths.
+- Implementation must stay minimal, auditable, and consistent with paranoid security model (frame validation, size/rate limits, no secrets in portal).
+
+This mechanism directly addresses resource usage concerns while enhancing the real-time feel of the dashboard.
 
 ## API for the Web Portal (Design + Current)
 The portal follows the design articulated in `docs/issue-35.md` (SDLC visibility, proposal→Court→build→PR→deploy transparency), `phase4-pr-system.md` (dashboard-optimized PRs, auto-creation), `docs/specs/chat-ui-data-flow.md`, E2E contract in `web_portal_e2e_sdlc_test.go`, and trusted bridge list in `dashboard_daemon.go`.
@@ -173,12 +214,12 @@ The shapes for dashboard PRs/Court are defined in `dashboard_pr_handlers.go` (`d
 
 All public API calls from browser are untrusted by default (unless marked); sensitive ones require the approval flow or future auth.
 
-**Contract tests**: `portal_contract_test.go` locks event JSON for dashboard consumers. Extend for new API responses.
+**Contract tests**: `portal_contract_test.go` locks event JSON for dashboard consumers. Extend for new STOMP payloads and API responses.
 
 ## Testability & E2E
 - Stable elements for Playwright (data-testid recommended for future; current uses IDs/classes).
-- E2E: `web_portal_e2e_sdlc_test.go` (full autonomous proposal→Court→PR→deploy via portal API + UI).
-- Unit: server_test.go (stubs), internal tests.
+- E2E: `web_portal_e2e_sdlc_test.go` (full autonomous proposal→Court→PR→deploy via portal API + UI). **Extend for STOMP connection, subscribe/unsubscribe, and topic-specific delivery.**
+- Unit: server_test.go (stubs), internal tests. Add STOMP frame and subscription manager tests.
 - Must handle backend unavailability gracefully (error banners, empty states).
 - Per testing-standards: E2E for portal flows required for journey completion.
 
@@ -186,25 +227,28 @@ All public API calls from browser are untrusted by default (unless marked); sens
 - Same as `web-portal-vm.md`: zero privileges, input untrusted, no secrets, mediated.
 - All mutations (edits, decisions, chat) go through validated API + Court where required.
 - Sanitization in chat renderer (link/protocol checks, HTML escape).
+- STOMP implementation: frame validation, size limits, rate limiting, no secret exposure. All traffic proxied.
 
 ## Related Documents & Traceability
 - `web-portal-vm.md`, `web-portal-screens.md` (legacy wireframes)
 - `issue-35.md` (SDLC portal vision + gaps that drove Canvas/PRs/Source/Workspace/Git)
 - `phase4-pr-system.md` (PR dashboard handlers, auto-create, fields)
-- `chat-ui-data-flow.md` (streaming/RAIL requirements)
+- `chat-ui-data-flow.md` (streaming/RAIL requirements; update for STOMP per-conversation path)
+- `event-system.md` (now includes STOMP gateway role)
 - `architecture.md`, `prd/sdlc-governance.md`, `specs/governance-court.md`
 - `cmd/aegisclaw/portal_contract_test.go`, `web_portal_e2e_sdlc_test.go`
 - `dashboard_daemon.go` (bridge + trusted actions)
 - User journeys #2,3,4,5,6,9 (chat, monitoring, proposals/court, SDLC)
 
-**Driven by**: All user journeys involving visibility/control; Phase 2-4 roadmap items; paranoid transparency requirement.
+**Driven by**: All user journeys involving visibility/control; Phase 2-4 roadmap items; paranoid transparency requirement; explicit goal to reduce real-time data transfer and compute via topic subscriptions.
 
 ## Open / Next (from gaps + code review)
 - Wire/register remaining `git.*`/`workspace.*`/`dashboard.skills` (or migrate to canonical `proposal.*`/`pr.*`/`skill.*`).
 - Implement full public `/api/proposals*` + rich PR/Court REST per design + E2E.
+- **Implement STOMP gateway and topic handlers in dashboard server** (per new STOMP section); extend contract tests and Playwright coverage.
 - Add `data-testid` + Playwright coverage for all new screens (Canvas, detailed chat streaming, proposal rounds, workspace edit, source browse).
 - Expand Canvas to full team graph + autonomy controls.
 - SBOM / gate results / diff viewers in PR/Proposal detail (per issue-35 phases 4-5).
 - Update `additional-requirements-and-gaps.md` and this spec as wiring completes.
 
-Update `CHANGELOG.md` on major portal milestone completion.
+Update `CHANGELOG.md` on major portal milestone completion (including STOMP real-time).


### PR DESCRIPTION
This PR adds and updates specifications to support using STOMP over WebSocket in the web portal for fine-grained topic subscriptions (e.g. `/topic/overview.stats`, `/topic/conversation.{sessionId}.updates`, approvals, canvas events).

**Motivation**
The current global SSE `/events` ticker + chat hybrid streaming works but is indiscriminate: all connected clients receive bundles of updates regardless of what view they're on. This leads to unnecessary network transfer and portal compute (filtering, serialisation, bridge traffic). STOMP pub/sub lets the browser explicitly `SUBSCRIBE` / `UNSUBSCRIBE` to only the topics it needs, with the portal acting as a lightweight trusted gateway that routes only relevant `MESSAGE` frames.

**Changes**
- `docs/specs/event-system.md`: Added new section "STOMP Topic Subscriptions for Presentation Layer" describing the gateway role, topic conventions, benefits, transition plan, security constraints, and mapping to internal event system. Updated Use Cases, Related Documents, and Implementation Status.
- `docs/specs/web-portal.md`: 
  - Updated Architecture, Data flow, Styling/JS, Real-time sections to reference STOMP evolution.
  - Updated Key Features & Screens (Overview, Canvas, Chat, Approvals) to call out topic usage.
  - Added comprehensive new section "STOMP Topic Subscriptions (New Real-Time Mechanism)" covering rationale, architecture (Go WS handler + client JS), initial topics, client lifecycle, performance wins, migration strategy, non-goals, and constraints (keeps presentation-only + isolation model).
  - Updated Testability, Security, Related Documents, Open/Next items, and contract test notes to include STOMP.

**Benefits**
- Reduced data transfer and resource usage (compute/network) as requested.
- Explicit subscribe/unsubscribe lifecycle aligned with UI navigation.
- Better multi-tab/view experience.
- Preserves all existing security, mediation (Host proxy + AegisHub), and minimal TCB principles.
- Coexists with current SSE during transition; Playwright/E2E coverage to be extended.

This is **specification-only**. Implementation (STOMP frame handling in dashboard server, JS client integration, topic routing) will follow in subsequent PR(s) once the spec is reviewed and aligned.

Branch: `spec/webportal-stomp-topics` (created from main).

Ready for review. Feedback on topic naming, STOMP subset, or integration points welcome!