### PR TITLE
docs: Add target-state Web Portal specifications

### DIFF
--- a/docs/specs/web-portal/canvas.md
+++ b/docs/specs/web-portal/canvas.md
@@ -1,0 +1,81 @@
+# Canvas (Inter-Agent Pipeline View) Specification
+
+**Status**: Target State
+
+## Overview
+
+Canvas provides a visual, high-level workspace for watching multiple specialized agents collaborate on a goal in parallel. It makes the harness (narrow-scope task decomposition, parallel execution, and stage progression) visible and understandable at a glance.
+
+It complements the Channels activity feed (which is more message-oriented) by offering a structured, pipeline-oriented view of inter-agent work.
+
+## Goals
+
+- Show parallel narrow tasks and their progress in context of the overall plan.
+- Make hand-offs, dependencies, and stage progression visible.
+- Provide quick drill-down to Single-Agent Trace, originating Channel, or Court proposals.
+- Support monitoring of multi-agent collaboration without requiring the user to read every message.
+- Reinforce the harness principles (narrow scope + parallel work + structured stages).
+
+## Layout
+
+- Top: Context header showing the current goal/plan and originating channel (with link).
+- Main area: Visual representation of active agents/tasks and pipeline stages.
+- Side or bottom panels: Shared artifacts, dependency overview, and quick actions.
+
+### Agent / Task Cards or Grid
+
+Each active agent or narrow task is represented with:
+- Assigned persona / role
+- Current narrow scope or sub-task
+- Progress indicator and current stage
+- Status (active, waiting, completed, blocked)
+- Recent key action or output summary
+- Quick links to trace or channel
+
+Cards can be arranged in a grid, kanban-style columns by stage, or a lightweight flow visualization.
+
+### Pipeline / Stage Visualization
+
+A clear representation of the overall pipeline stages (Plan → Delegate → Execute → Propose → Court Review → Apply) with status per stage and connections between parallel tasks where relevant.
+
+This makes the structured, validated flow of work immediately apparent.
+
+### Shared Artifacts Panel
+
+- Research notes, diffs, plans, or other artifacts produced by the agents.
+- Links to relevant proposals or traces.
+
+## Real-Time Behavior
+
+Live updates via STOMP topics for:
+- Agent/task status and progress changes
+- New narrow tasks being delegated
+- Stage transitions
+- New artifacts or proposals
+
+The view stays current as agents work in parallel.
+
+## Interaction Patterns
+
+- Clicking an agent card or task opens the Single-Agent Trace view.
+- Clicking a stage or proposal link opens the relevant Court detail.
+- "Open in Channel" returns to the full activity feed context.
+- Ability to pause/resume individual narrow tasks or the overall work from this view.
+
+## Edge Cases
+
+- Few active agents: Graceful empty or minimal state with link back to the originating channel.
+- Many parallel tasks: Good grouping, filtering, and visual hierarchy to avoid overload.
+- Long-running work: Clear progress indicators and time context.
+
+## Persona Considerations
+
+- **Sam Chen / Jordan Hale**: Excellent for monitoring team or feature work with multiple agents collaborating.
+- **Alex Rivera**: Quick path from visual overview to deep individual traces.
+
+## Open Areas
+
+- Preferred visualization style (cards + pipeline strip vs. interactive graph vs. kanban).
+- Level of detail shown on cards by default.
+
+This specification defines the target Canvas experience.

--- a/docs/specs/web-portal/channels.md
+++ b/docs/specs/web-portal/channels.md
@@ -1,0 +1,152 @@
+# Channels Specification
+
+**Status**: Target State
+
+## Overview
+
+Channels are the primary collaborative workspaces in the AegisClaw Web Portal. They serve as scoped, persistent environments where humans and specialized agents collaborate on goals under governance.
+
+Each channel provides:
+- A shared activity feed for human messages and agent updates.
+- Visible decomposition of work into narrow tasks assigned to specific agent personas (the harness in action).
+- Grouped, low-friction member management.
+- Embedded governance through Court proposals that arise naturally from the work.
+- Real-time updates and intervention capabilities.
+
+Channels follow Slack-inspired patterns for scannability and low cognitive load while making the multi-agent harness and adversarial review process transparent.
+
+## Goals
+
+- Enable focused collaboration without visual or informational overwhelm.
+- Make the PM-orchestrated narrow-task decomposition and parallel execution visible and understandable.
+- Support natural human intervention via @mentions and quick input.
+- Surface governance events (proposals, votes, rationales) inline where relevant.
+- Provide clear paths to deeper views (single-agent traces, Canvas, Court detail).
+
+## Layout & Structure
+
+Channels use a three-zone desktop layout:
+
+- **Left sidebar**: Scannable channel list + quick actions.
+- **Main content area**: Channel header, harness/pipeline overview, activity feed, and input.
+- **Right context panel**: Channel-specific context, grouped member management, security posture, and quick actions.
+
+The layout is responsive:
+- Desktop: full three-zone with collapsible right panel.
+- Mobile: right context collapses to a bottom sheet triggered from header or floating action. Main area includes a persistent quick-command affordance near the top and an Agent Activity Summary component.
+
+### Left Sidebar
+
+- List of channels with name, member count or "X active", last activity timestamp, and status indicator (e.g., "Governance active", "Background work").
+- Search and filter capability.
+- Quick actions: New Channel (with optional goal prefill), New Team, Propose Skill (scoped to current context).
+
+### Main Area
+
+**Channel Header**
+- Channel name and short description.
+- Status badges.
+- Archive button (with confirmation).
+
+**Harness / Pipeline Overview (Compact Harness)**
+A prominent but calm strip or card group that shows:
+- The current high-level plan or goal.
+- Decomposition into narrow-scope tasks with assigned specialist personas.
+- Progress and status per task/stage.
+- Visible pipeline stages: Plan → Delegate → Execute → Propose → Court Review → Apply.
+
+This section makes the harness principles immediately visible without requiring the user to open separate views. It serves as the low-friction entry point to the richer Canvas view.
+
+**Activity Feed**
+The core of the channel. Real-time feed containing:
+- Human messages.
+- Proactive agent updates and status reports.
+- Tool calls and results (sanitized).
+- Inter-agent hand-offs and collaboration events.
+- Proposal and Court decision events (with vote summaries and links).
+
+**Reasoning Visibility (Progressive default)**
+- Live/in-flight agent reasoning steps (Observe → Think → Plan → Act, tool calls) are expanded and highlighted for live observability.
+- Once a decisive result, proposal, or stage transition occurs, intermediate reasoning automatically collapses to a compact one-line summary (e.g. "Researcher completed scope with 3 tool calls") with a clear "Show reasoning" affordance.
+- Human messages and Court decisions remain fully expanded.
+- Feed-level controls ("Collapse all reasoning", "Expand recent") are available in the header or feed menu to manage density, especially valuable on mobile.
+- Policy presets (Progressive / Paranoid / Velocity) are available globally and per-channel; enterprise policy can lock the preset.
+
+Features:
+- Threading for focused discussion.
+- @mention autocomplete for both humans and agent roles/personas (project-manager, ciso-persona, researcher, etc.).
+- Visual distinction for proactive/agent-generated updates.
+- Streaming support for live agent output (Markdown deltas, thought logs, tool logs).
+- Search and filter within the feed (by participant, type, date).
+
+**Quick Input Bar**
+Natural language input at the bottom of the feed.
+- Supports @mentions.
+- High-privilege or high-risk actions trigger clear approval prompts before execution.
+- Send action routes through the PM or relevant agent as appropriate.
+
+**Agent Activity Summary**
+Lightweight chips or cards in the header area showing:
+- Currently active narrow tasks and personas
+- Overall stage progress
+- Token usage or activity cost (when safely exposed by the backend)
+
+This gives at-a-glance visibility into what work is happening and what resources it is consuming, directly supporting velocity and governance needs.
+
+### Right Context Panel
+
+**Channel Context**
+- Pending proposals count with direct link to Court.
+- Recent decisions summary.
+- Shared artifacts or memory context relevant to the channel.
+
+**Grouped Member Management**
+Focused, searchable interface with collapsible sections:
+
+- **Core Court** (7 personas): Role, last activity or vote, "View trace" link.
+- **Project / SDLC Roles**: Unique project-manager and specialists with current status.
+- **Humans / Operators**: Current user and other human participants with easy add/remove.
+
+Management actions (invite human or specialist agent, remove, view profile/trace) are available inline or via a clean modal. No flat, overwhelming lists of every persona by default.
+
+**Security Posture**
+Channel or context-specific security indicators (consistent with global posture but scoped).
+
+**Quick Actions**
+Contextual buttons such as:
+- Invite specialist
+- Propose change to this channel
+- Review pending Court decisions
+- Open in Canvas
+- Quick export of recent artefacts (from completed proposals)
+
+## Real-Time Behavior
+
+- Per-channel STOMP topics for activity feed updates, member status changes, and proposal events.
+- Subscription managed on channel view mount/unmount.
+- Graceful fallback to SSE if STOMP is unavailable.
+- Live indicators for active agents/personas in the member section.
+
+## Interaction Patterns & Edge Cases
+
+- **Empty or new channel**: Helpful guidance such as "Give the PM a goal to get started" or template suggestions that trigger plan creation.
+- **High volume of activity**: Good default filtering (e.g., show decisions + proactive updates first) and threading. Progressive reasoning collapsing helps maintain scannability.
+- **Many members**: Sections are collapsed by default; search works across all groups.
+- **Proposal arising from work**: Appears inline in the activity feed with clear status and link to full Court detail. Quick export action available.
+- **Agent spin-up time**: Graceful loading states that mask microVM startup while showing the harness is working.
+
+## Persona Considerations
+
+- **Alex Rivera**: Easy access to traces from the member list and prominent Court rationales in the feed. Progressive reasoning gives depth without permanent noise.
+- **Jordan Hale / Sam Chen**: Clear role visibility, @mention power, export paths from proposals, and the Agent Activity Summary for token/work visibility. Velocity preset available.
+- **Dr. Lena Moreau**: Governance status and proposal visibility at the channel level. Paranoid preset and quick exports support compliance needs.
+
+## Open Areas
+
+- Exact visual treatment of the pipeline overview (cards vs horizontal strip vs progress indicators).
+- Member invite flow details (modal vs drawer).
+- Thread vs flat feed preference (user testing).
+- Performance targets for very long activity histories.
+- Exact mobile bottom-sheet interaction details and pull-to-refresh behaviour.
+
+This specification defines the target behavior for Channels. Implementation should prioritize scannability, harness visibility, and low-friction collaboration.

--- a/docs/specs/web-portal/court.md
+++ b/docs/specs/web-portal/court.md
@@ -1,0 +1,80 @@
+# Court / Governance Hub Specification
+
+**Status**: Target State
+
+## Overview
+
+The Court is the dedicated governance surface where adversarial multi-persona review happens. It makes the structured validation pipeline (proposals → security gates → per-persona review and voting → decisions) transparent, actionable, and exportable.
+
+It embodies the Cloudflare-inspired principle of deliberate disagreement and structured validation, turning what could be opaque agent behavior into auditable, explainable governance.
+
+## Goals
+
+- Provide clear visibility into pending and recent proposals with status, votes, and rationales.
+- Enable efficient review and decision-making (approve, reject, defer, comment).
+- Support export of structured artifacts for compliance, diligence, and audit needs.
+- Make the adversarial nature of the Court (multiple personas in deliberate review) visible and trustworthy.
+- Link seamlessly back to originating Channels and forward to implementation artifacts.
+
+## Layout
+
+- Top: Filters (Status, Channel, Persona, Date range, Urgency, Search).
+- Main area: Proposal list (cards or table) + detail pane or modal.
+- Optional right panel: Summary stats, quick filters, and export actions.
+
+### Proposal List
+
+Each proposal shows:
+- Title and short description
+- Originating channel (link)
+- Current status (Pending, Approved, Rejected, etc.)
+- Vote summary (e.g., "7/7 Approved" or "4/7 – 2 needed")
+- Security gate status (green checks or warnings for SAST, SCA, secrets, etc.)
+- Age and last activity
+
+Clicking a proposal opens the detail view.
+
+### Detail View
+
+Shows:
+- Full metadata and structured pipeline stages reached.
+- Per-persona vote cards with short rationales, timestamps, and verdict badges.
+- Diffs or links to changed artifacts.
+- Full security scan results.
+- Comments and discussion thread.
+
+Actions available:
+- Approve / Reject / Defer (with optional note)
+- Comment
+- Batch actions when multiple proposals are selected
+- Export (structured report, SBOM mapping, regulatory export)
+
+## Real-Time Behavior
+
+Live updates when:
+- New proposals appear
+- Votes are cast
+- Status changes occur
+
+STOMP topics keep the list and detail view current without full page reloads.
+
+## Edge Cases
+
+- No pending proposals: Calm state with link to recent history and overall governance health.
+- High volume: Excellent filters, search, and prioritization (e.g., oldest first or highest risk).
+- Export needs: One-click structured exports tailored for Jordan (investor diligence) and Lena (compliance) use cases.
+
+## Persona Considerations
+
+- **Alex Rivera**: Plain-English rationales, easy deferral, clear path to traces.
+- **Jordan Hale**: Exportable audit trails and "simulate stricter review" context.
+- **Dr. Lena Moreau**: Policy alignment, structured exports, and fleet-level visibility.
+- All personas benefit from visible adversarial review (deliberate disagreement across personas).
+
+## Open Areas
+
+- Exact export formats and compliance mapping.
+- Batch decision UX patterns.
+- How proposal priority/urgency is calculated and displayed.
+
+This specification defines the target Court experience.

--- a/docs/specs/web-portal/dashboard.md
+++ b/docs/specs/web-portal/dashboard.md
@@ -1,0 +1,88 @@
+# Dashboard & Monitoring Specification
+
+**Status**: Target State
+
+## Overview
+
+The Dashboard provides a global, at-a-glance view of all active work across the system, along with monitoring, intervention, and high-level metrics. It is the primary surface for operators and leads who need to understand system-wide state without being inside a specific channel.
+
+It complements Home (which focuses on immediate productivity and contextual suggestions) by owning global metrics and active work oversight.
+
+## Goals
+
+- Deliver clear visibility into running agents, background tasks, and pending governance work.
+- Enable quick drill-down into detailed views (Single-Agent Trace, Canvas, Court, Channel).
+- Support intervention (pause, resume, cancel) with appropriate safeguards.
+- Show the health of the harness (parallel narrow tasks, adversarial review activity) at a system level.
+- Keep metrics and monitoring scoped here so Home remains focused on action.
+
+## Layout
+
+- Top: Search + view filters (All, By Channel, By Persona/Role, Background Tasks only, Pending Proposals only).
+- Prominent but calm metrics row.
+- Main area: Grouped or tabbed lists/cards of active work.
+- Optional right or bottom panel: Aggregate security posture, harness health indicators, and recent global activity.
+
+### Metrics Row
+
+- Active Agents (total + breakdown by role or channel)
+- Background Tasks (count + average progress)
+- Pending Proposals (count + oldest or highest urgency)
+- Optional: Running MicroVMs, resource usage summary (if relevant and not noisy)
+
+These are live-updating and clickable where appropriate to filter the main lists.
+
+### Active Work Views
+
+Main content area shows active agents, tasks, and proposals in card or list form. Each item includes:
+- Narrow scope or task description
+- Assigned persona(s) or role
+- Current stage / progress indicator
+- Last update timestamp
+- Originating channel (with link)
+- Quick actions (Pause, Watch in Canvas, View Trace, Review Proposal)
+
+Grouping options:
+- By Channel
+- By Persona / Role
+- By Stage (Plan, Execute, Court Review, etc.)
+- Flat with strong filtering
+
+### Intervention Controls
+
+Direct controls for running work:
+- Pause / Resume / Cancel on agents or background tasks
+- Confirmation dialogs for high-impact actions
+- Clear explanation of consequences (e.g., "This will stop the current narrow task and notify the PM")
+
+"Watch live" or "Open in Canvas" buttons for visual monitoring of multi-agent work.
+
+## Real-Time Behavior
+
+Heavy use of STOMP topic subscriptions for:
+- Live metric updates
+- New or updated active work items
+- Proposal status changes
+- Agent state transitions
+
+Subscriptions are view-specific and cleaned up on navigation away.
+
+## Edge Cases & Empty States
+
+- No active work: Helpful guidance linking back to Home command bar or quick-start templates.
+- Very high activity: Strong default filters and grouping to prevent overload.
+- Long-running background tasks: Clear progress indicators and estimated completion where available.
+
+## Persona Considerations
+
+- **Sam Chen** (Tech Lead): Team-wide oversight, easy filtering by channel or role, quick intervention.
+- **Alex Rivera**: Easy path from global view to individual agent traces.
+- **Dr. Lena Moreau**: Visibility into pending governance work and security posture at scale.
+
+## Open Areas
+
+- Exact visual design of the metrics row and work cards.
+- Default filter and grouping preferences.
+- How resource usage (if shown) is presented without creating noise.
+
+This specification defines the target Dashboard & Monitoring experience.

--- a/docs/specs/web-portal/design-tokens-and-components.md
+++ b/docs/specs/web-portal/design-tokens-and-components.md
@@ -1,0 +1,121 @@
+# Design Tokens & Component Patterns Specification
+
+**Status**: Target State (Canonical Source)
+
+## Overview
+
+This document is the **single source of truth** for design tokens and component patterns in the AegisClaw Web Portal. All other documents should reference this file for visual and structural consistency.
+
+## Color Palette (Canonical)
+
+**Base**
+- Background: `#0a0a0a`
+- Surface / Cards: `#1f1f1f`
+- Elevated surfaces: `#2a2a2a`
+
+**Text**
+- Primary: `#e0e0e0`
+- Secondary / Muted: `#8b949e`
+
+**Semantic Colors**
+- Primary / Focus / Links: `#00d4ff`
+- Success / Running / Approved: `#22ff88`
+- Warning / Pending: `#ffcc00`
+- Danger / Rejected / Error: `#ff3333`
+
+**Borders**
+- Default: `#333333`
+- Focus: `#00d4ff`
+
+All colors should be defined as CSS custom properties (e.g., `--color-bg`, `--color-primary`, `--color-success`).
+
+## Typography
+
+- System UI stack for body text
+- Monospace stack for code, logs, and traces
+
+## Spacing
+
+Base unit: 4px (multiples of 4 recommended). Generous application for breathing room in command surfaces and feeds.
+
+## Interaction States
+
+- Hover: subtle surface lift or border highlight
+- Focus: cyan ring (`--color-focus`) with 2px offset
+- Active / Pressed: slight scale or background shift
+- Disabled: muted text and reduced opacity
+- Loading / Skeleton: calm pulse or static placeholder blocks matching surface colour
+
+## Component Patterns
+
+### Cards
+- Elevated surface background
+- Consistent padding (16px or 24px)
+- Subtle elevation via shadow or border
+
+### Badges & Status
+- Semantic color coding as defined above
+- Small, readable, consistent across views
+- Compact variants for Activity Summary chips
+
+### Timeline / Trace
+- Clear phase separation
+- Expandable tool call details
+- Good visual hierarchy
+- Collapsible by default for completed sections in feeds
+
+### Pipeline Stages (Compact Harness)
+- Horizontal or vertical representation of Plan → Delegate → Execute → Propose → Court Review → Apply
+- Current stage highlighted with semantic colour
+- Completed stages in success colour
+- Compact version for Channels and Home headers
+
+### Member Representation
+- Grouped by category (Core Court, Project Roles, Humans) with collapsible sections
+- Status indicators and consistent chip/avatar treatment
+- Searchable within groups
+
+### Collapsible Sections
+- Clear affordance (chevron or "Show/Hide" text)
+- Smooth height transition
+- Default collapsed for reasoning steps (post-decision), member groups, and long traces
+- Live/in-flight sections start expanded
+- Persist user preference where appropriate (e.g. per-channel reasoning collapse state)
+
+### Bottom Sheets (Mobile Context)
+- Slide-up from bottom with backdrop
+- Header with title and close affordance
+- Scrollable content area
+- Safe-area padding for device notches
+- Used for right-context content (member management, harness details, operator controls) on mobile
+- Dismiss on backdrop tap or swipe down
+
+### Agent Activity Summary
+- Lightweight horizontal chip row or small card group
+- Shows: active narrow tasks/personas, overall stage progress, token usage (when exposed)
+- Semantic colour for status
+- Clickable to open deeper view (Dashboard or Canvas)
+- Appears in Home header (desktop), Channels header area (desktop + mobile), and Dashboard
+- Graceful empty state when no active work
+
+### Policy / Preset Toggles
+- Clear segmented control or dropdown for Progressive / Paranoid / Velocity presets
+- Visual indicator of current policy
+- Per-channel override option with clear inheritance note
+- Enterprise lock state shown with admin-only messaging
+- Placed in Settings, Channel header menu, or operator context panel
+
+### Pipeline Stages (Expanded / Canvas)
+- Richer visual representation when opened from Compact Harness strip
+- Supports grid/kanban or lightweight flow view of parallel tasks
+- Direct links to traces and proposals
+
+## Accessibility
+
+- WCAG AA minimum contrast
+- Visible focus states (cyan ring)
+- Proper ARIA for dynamic content (expanded/collapsed states, live regions for activity feed and Agent Activity Summary)
+- Minimum 44px touch targets on mobile
+- Keyboard navigation support for all interactive elements including bottom sheets and policy toggles
+
+This document should be referenced by all other specification files when describing visual elements. New components (Agent Activity Summary, bottom sheets, policy toggles) must follow the patterns defined here.

--- a/docs/specs/web-portal/export-formats.md
+++ b/docs/specs/web-portal/export-formats.md
@@ -1,0 +1,38 @@
+# Export Formats & Compliance Artifacts Specification
+
+**Status**: Target State
+
+## Overview
+
+This document defines the expected export capabilities from the Court / Governance Hub and related areas.
+
+## Export Use Cases
+
+- Investor / diligence reports (Jordan Hale persona)
+- Compliance and regulatory mapping (Dr. Lena Moreau persona)
+- Internal audit trails
+
+## Required Export Types
+
+- Structured proposal + decision report (including per-persona rationales and votes)
+- SBOM and security gate results for approved changes
+- Regulatory mapping exports (where applicable)
+- Full audit trail for a proposal or channel
+
+## Format Recommendations
+
+- Primary format: Well-structured Markdown or JSON for machine readability
+- Secondary: PDF for human review and sharing
+- Include clear metadata (timestamps, proposal ID, originating channel, participants)
+
+## Security & Privacy
+
+- Exports must respect the same sanitization rules as the UI (no secrets or internal details leaked).
+- Access to export functionality should be governed by appropriate permissions.
+
+## Implementation Notes
+
+- Exports should be generated on demand from the authoritative data in the Store / Host.
+- Consider adding a "Generate Report" action in the Court detail view with format options.
+
+This capability is particularly important for building trust with security-conscious and enterprise users.

--- a/docs/specs/web-portal/harness-pipeline-data-model.md
+++ b/docs/specs/web-portal/harness-pipeline-data-model.md
@@ -1,0 +1,132 @@
+# Harness Pipeline Data Model Specification
+
+**Status**: Target State
+
+## Overview
+
+This document defines how the harness (PM-orchestrated narrow tasks, parallel execution, and structured pipeline stages) is represented in data and surfaced in the Web Portal. A clear, consistent data model is essential for making the harness visible and understandable across Home, Channels, Canvas, Dashboard, and Court.
+
+## Core Concepts
+
+- **Goal / Plan**: The high-level intent provided by the user (or derived by the PM).
+- **Narrow Task**: A decomposed, scoped unit of work assigned to a specific specialist agent persona.
+- **Pipeline Stage**: One of: Plan → Delegate → Execute → Propose → Court Review → Apply.
+- **Agent Instance**: A running microVM executing a narrow task.
+- **Progress**: Status of a task or stage.
+
+## Data Model (Target)
+
+### Plan / Goal
+```json
+{
+  "plan_id": "plan_abc123",
+  "channel_id": "chan_main",
+  "goal": "Research and compare Zig vs Rust for home lab scripts",
+  "created_at": "2026-06-17T...",
+  "status": "active",
+  "stages": [
+    {"name": "Plan", "status": "completed"},
+    {"name": "Delegate", "status": "completed"},
+    {"name": "Execute", "status": "in_progress"},
+    {"name": "Propose", "status": "pending"},
+    {"name": "Court Review", "status": "pending"},
+    {"name": "Apply", "status": "pending"}
+  ]
+}
+```
+
+### Narrow Task
+```json
+{
+  "task_id": "task_xyz789",
+  "plan_id": "plan_abc123",
+  "agent_persona": "researcher",
+  "scope": "Research Zig language features with focus on security model",
+  "status": "active",
+  "current_stage": "Execute",
+  "progress": 65,
+  "last_update": "2026-06-17T...",
+  "agent_instance_id": "agent_vm_456"   // Internal only - do not expose to browser
+}
+```
+
+## Event Types & Payloads (Real-time Updates)
+
+The following events are pushed via STOMP (see `real-time-contracts.md`) to keep the UI in sync:
+
+### `harness.plan.created`
+```json
+{
+  "type": "harness.plan.created",
+  "plan_id": "plan_abc123",
+  "channel_id": "chan_main",
+  "goal": "...",
+  "stages": [...]
+}
+```
+
+### `harness.task.assigned`
+```json
+{
+  "type": "harness.task.assigned",
+  "task_id": "task_xyz789",
+  "plan_id": "plan_abc123",
+  "agent_persona": "researcher",
+  "scope": "...",
+  "current_stage": "Execute"
+}
+```
+
+### `harness.task.progress`
+```json
+{
+  "type": "harness.task.progress",
+  "task_id": "task_xyz789",
+  "progress": 65,
+  "current_stage": "Execute",
+  "summary": "Found 12 relevant papers on Zig security model"
+}
+```
+
+### `harness.stage.transition`
+```json
+{
+  "type": "harness.stage.transition",
+  "plan_id": "plan_abc123",
+  "stage": "Propose",
+  "status": "in_progress",
+  "related_task_ids": ["task_xyz789"]
+}
+```
+
+### `harness.proposal.created`
+```json
+{
+  "type": "harness.proposal.created",
+  "plan_id": "plan_abc123",
+  "task_id": "task_xyz789",
+  "proposal_id": "prop_def456",
+  "stage": "Court Review"
+}
+```
+
+**Important**: The portal should treat `agent_instance_id` as internal and never display or log it.
+
+## Visibility in UI Surfaces
+
+- **Channels**: Shows current plan + active narrow tasks + stage progress strip.
+- **Canvas**: Visual cards for tasks + pipeline stages.
+- **Dashboard**: Aggregated active tasks filterable by stage/persona.
+- **Court**: Proposals linked back to originating plan/task.
+
+## Security Considerations
+
+- Never expose `agent_instance_id` or raw internal identifiers to the browser.
+- Scope descriptions should be sanitized.
+- Access to plan/task data must respect channel membership.
+
+## Implementation Notes
+
+- Use shared types between Host and Portal where possible.
+- Prefer delta updates over full snapshots for real-time efficiency.
+- The portal must treat harness state as read-only.

--- a/docs/specs/web-portal/implementation-gaps-and-priorities.md
+++ b/docs/specs/web-portal/implementation-gaps-and-priorities.md
@@ -1,0 +1,98 @@
+# Implementation Gaps & Priorities
+
+**Status**: Target State / Living Document
+
+## Purpose
+
+This document consolidates the remaining open questions, considerations, and areas that require additional specification for a high-quality implementation of the Web Portal. It serves as a single reference for implementors and reviewers.
+
+It is intended to be updated as new specifications are created.
+
+## Completed / Well-Covered Areas
+
+The following areas have dedicated target-state specifications:
+
+- Overall portal vision, principles, and page behaviors (`web-portal.md` + per-page specs)
+- Real-time communication contracts and STOMP usage (`real-time-contracts.md`)
+- Security boundaries, sanitization, input validation, and rate limiting (`security-boundaries.md`)
+- Harness / pipeline data model and visibility (`harness-pipeline-data-model.md`)
+- Channel collaboration, activity feed, and member management (`channels.md` + `member-management-flow.md`)
+- Court / governance flows and adversarial review (`court.md`)
+- Dashboard, monitoring, and intervention (`dashboard.md`)
+- Canvas / inter-agent pipeline visualization (`canvas.md`)
+- Single-agent trace and deep observability (`single-agent-trace.md`)
+
+## Remaining Open Areas (Prioritized)
+
+### High Priority (Recommended before major implementation)
+
+1. **Harness Pipeline Data Model – Refinement**
+   - More precise schemas for how the PM communicates narrow tasks, stage transitions, and progress to the portal.
+   - Event types and payload deltas for real-time updates.
+   - Status: Partially covered in `harness-pipeline-data-model.md`; needs tighter integration with STOMP contracts.
+
+2. **Design Tokens & Component Patterns**
+   - Official design tokens (colors, typography, spacing, shadows, focus states, loading states).
+   - Reusable component patterns (cards, badges, timelines, pipeline indicators, member chips).
+   - Dark theme specifics and accessibility (contrast, focus management).
+   - Status: Not yet documented in detail.
+
+3. **Performance Targets & Virtualization**
+   - Specific targets for concurrent connections, render performance, and trace/feed length before virtualization or pagination is required.
+   - Strategy for virtual scrolling in long activity feeds and traces.
+   - Memory and CPU budgets for the portal VM under load.
+   - Status: Not yet specified.
+
+### Medium Priority
+
+4. **Onboarding, Suggestions Engine & Empty States**
+   - Exact logic for detecting first-time vs returning users.
+   - Rules and data sources for contextual suggestions on Home.
+   - Standardized empty state and guidance copy across views.
+   - How external signals (news, market data, etc.) are sourced and filtered securely.
+   - Status: High-level guidance exists; detailed rules needed.
+
+5. **Export Formats & Compliance Artifacts**
+   - Exact data shapes and file formats for Court exports (structured reports, SBOM mapping, regulatory artifacts).
+   - How proposal metadata and rationales are serialized for diligence/compliance use cases.
+   - Status: Mentioned in `court.md`; needs concrete schemas.
+
+6. **Testing & Contract Strategy**
+   - E2E test coverage matrix (which journeys and edge cases require Playwright coverage).
+   - Contract tests for STOMP payloads and bridge actions.
+   - Strategy for testing real-time behavior reliably.
+   - Stable `data-testid` and selector guidelines.
+   - Status: Partially implied; needs explicit document.
+
+### Lower Priority / Nice to Have
+
+7. **Detailed Component Interaction Specs**
+   - State machines or detailed interaction flows for complex components (Command Bar + plan preview, Grouped Member Management, Proposal voting).
+   - Loading, error, and optimistic update patterns.
+
+8. **Member Permission Model Details**
+   - Fine-grained permissions for who can invite/remove specific member types.
+   - Governance requirements for adding powerful Court or specialist personas.
+
+9. **Internationalization & Accessibility**
+   - i18n strategy and requirements.
+   - Detailed a11y requirements beyond basic contrast and keyboard navigation.
+
+## Recommended Implementation Order
+
+1. Finalize Harness Pipeline Data Model + integrate with real-time contracts.
+2. Define Design Tokens & core component patterns (this unblocks consistent UI implementation).
+3. Establish Performance Targets & virtualization approach.
+4. Create Testing & Contract Strategy document.
+5. Detail Onboarding / Suggestions logic and Export Formats.
+6. Address remaining lower-priority items as needed during development.
+
+## How to Use This Document
+
+- Implementors should treat items marked High Priority as blocking for a production-quality release.
+- New specifications should be created in this folder and referenced here.
+- This document should be updated when gaps are closed.
+
+## Next Steps
+
+The remaining high-priority items above are good candidates for the next specification documents to be created.

--- a/docs/specs/web-portal/member-management-flow.md
+++ b/docs/specs/web-portal/member-management-flow.md
@@ -1,0 +1,56 @@
+# Member Management Flow Specification
+
+**Status**: Target State
+
+## Overview
+
+Defines frontend patterns and backend requirements for managing channel participants (humans and agent personas).
+
+## Member Categories
+
+1. **Core Court** (7 fixed governance personas)
+2. **Project / SDLC Roles** (dynamic specialists)
+3. **Humans / Operators**
+
+## Frontend Patterns
+
+- Grouped, collapsible sections in the context panel
+- Searchable
+- "View Trace" for agents
+- Quick remove with confirmation
+
+## Invite Flow
+
+- Separate paths for humans and specialist agents
+- PM can suggest appropriate specialists based on current plan
+- Court personas require elevated confirmation or governance step
+
+## Remove Flow
+
+- Confirmation explaining impact
+- Court personas have restricted removal (requires higher privileges or governance)
+
+## Backend Requirements
+
+- Host enforces permission checks
+- Agent personas are spawned by PM when delegated tasks
+- All changes are auditable
+
+## Permission Model (Target)
+
+| Action                    | Humans          | Project Specialists | Core Court Personas      |
+|---------------------------|-----------------|---------------------|--------------------------|
+| Invite to channel         | Yes             | Yes (via PM)        | Restricted / Governance  |
+| Remove from channel       | Yes             | Yes                 | Restricted / Governance  |
+| View trace                | Yes             | Yes                 | Yes                      |
+| Trigger high-privilege actions | Limited    | Limited             | Governed by Court rules  |
+
+Court personas are generally pre-seeded or managed at a higher level. Adding or removing them typically requires explicit governance approval or elevated operator privileges.
+
+## Security Considerations
+
+- All membership changes go through the Host
+- Powerful personas require additional safeguards
+- Clean termination of agent microVMs on removal
+
+This model supports the collaboration model while maintaining security boundaries.

--- a/docs/specs/web-portal/onboarding-and-suggestions.md
+++ b/docs/specs/web-portal/onboarding-and-suggestions.md
@@ -1,0 +1,39 @@
+# Onboarding, Suggestions Engine & Empty States Specification
+
+**Status**: Target State
+
+## Overview
+
+This document defines the behavior for first-time user guidance, contextual suggestions on Home, and standardized empty states across the portal.
+
+## First-Time User Experience
+
+When a user has no previous activity:
+- Home should emphasize Quick Start options (Research a topic, Start a feature channel, Audit security posture, Propose custom skill).
+- Guidance should be helpful and non-intrusive.
+- The command bar should still be prominent so power users are not slowed down.
+
+## Contextual Suggestions
+
+Suggestions on Home should be driven by:
+- Recent activity in the user’s channels (e.g., "Review Court decision on discord_monitor").
+- Current background tasks or pending proposals.
+- Opted-in external signals (e.g., relevant news or releases related to active topics), with clear privacy controls.
+
+Suggestions must be dismissible and should not block the primary command bar.
+
+## Empty States
+
+Every major view should have a consistent, helpful empty state pattern:
+- Relevant icon or illustration
+- Clear headline
+- Supportive description
+- Optional primary action (e.g., "Start a new task" linking back to Home command bar)
+
+Tone should be encouraging rather than apologetic.
+
+## Implementation Notes
+
+- Detection of "first-time" vs "returning with activity" should be simple and reliable (based on presence of channels, recent events, or stored preferences).
+- Suggestion generation logic should be lightweight and respect user privacy settings.
+- Empty state content should be easy to update without code changes where possible.

--- a/docs/specs/web-portal/performance-targets.md
+++ b/docs/specs/web-portal/performance-targets.md
@@ -1,0 +1,65 @@
+# Performance Targets & Virtualization Strategy
+
+**Status**: Target State
+
+## Overview
+
+This document defines performance targets and strategies for handling large amounts of data in the Web Portal (long activity feeds, traces, Canvas views with many agents, etc.). Clear targets help implementors make good architectural decisions early.
+
+## Key Performance Areas
+
+### Concurrent Connections & Real-time
+
+- Target: Support at least 50–100 concurrent WebSocket / STOMP connections per portal instance under normal load.
+- Heartbeat and idle connection cleanup must be aggressive to prevent resource exhaustion.
+- Real-time updates should feel responsive (< 100–200ms perceived latency for most events under normal conditions).
+
+### Activity Feeds & Timelines
+
+- Target: Smooth rendering and scrolling for feeds containing 500–2000+ events without significant lag.
+- Virtualization (virtual scrolling) should be used once the visible list exceeds ~100–150 items.
+- Search and filtering within feeds should remain responsive even on large datasets.
+
+### Single-Agent Traces
+
+- Target: Comfortable handling of traces with 200–1000+ phases/tool calls.
+- Virtualization or progressive loading / collapsing should be applied for very long traces.
+- Expanding a tool call or phase should feel instant.
+
+### Canvas / Inter-Agent Views
+
+- Target: Smooth rendering of 20–50+ concurrent agents/tasks.
+- Updates to individual agent status or progress should not cause full re-renders of the view.
+- Visual pipeline indicators should update efficiently.
+
+### Dashboard / Monitoring
+
+- Target: Quick loading and filtering of lists containing hundreds of active agents/tasks.
+- Metrics cards should update in near real-time without expensive re-computation on the client.
+
+## Virtualization Strategy
+
+- Use virtual scrolling libraries or custom implementations for long lists (activity feeds, traces, member lists under high cardinality).
+- Prefer "windowing" techniques that only render items currently in or near the viewport.
+- For traces and feeds, consider hybrid approaches: keep recent items fully rendered + virtualized older items.
+- Maintain good keyboard navigation and accessibility even when virtualization is active.
+
+## Data Handling Recommendations
+
+- Prefer incremental updates (deltas) over full list replacements when possible.
+- Implement client-side caching with time-based or size-based eviction where appropriate.
+- For very large histories, consider server-side pagination or cursor-based loading with "Load more" or infinite scroll patterns.
+
+## Resource Budgets (Portal VM)
+
+- The portal VM should remain lightweight. Real-time processing and rendering should not cause excessive memory or CPU usage.
+- Target: Keep portal memory usage under control even with dozens of concurrent users and long-lived connections.
+- Monitor and set alerts for connection count, memory growth, and event processing rate on the Host side.
+
+## Implementation Notes
+
+- Choose virtualization solutions that are lightweight and have good accessibility support.
+- Test performance early with realistic data volumes (synthetic long feeds and traces).
+- Profile rendering performance in the browser during development of feed and trace views.
+
+Clear performance targets and a defined virtualization strategy will prevent major refactoring later when real usage data appears.

--- a/docs/specs/web-portal/real-time-contracts.md
+++ b/docs/specs/web-portal/real-time-contracts.md
@@ -1,0 +1,123 @@
+# Real-time Contracts Specification
+
+**Status**: Target State
+
+## Overview
+
+This document defines the real-time communication contracts for the Web Portal. It focuses on STOMP-over-WebSocket as the primary mechanism for efficient, targeted updates while maintaining the strict paranoid security model of AegisClaw.
+
+The portal must remain **presentation-only**. All real-time data originates from the Host Daemon via the vsock bridge. The portal never generates business logic or persists state.
+
+## Design Constraints (Paranoid Security)
+
+- Minimal TCB: The STOMP handler and client must be small, auditable, and self-contained.
+- No secrets or sensitive data may transit in a way that could be exposed to the browser.
+- All subscriptions are view-specific and must be cleaned up promptly.
+- Frame validation, size limits, and rate limiting are mandatory on the server side.
+- Fallback to existing SSE must remain functional and secure.
+
+## STOMP Protocol Subset
+
+The portal implements a minimal, safe subset of STOMP 1.2:
+- `CONNECT` / `CONNECTED`
+- `SUBSCRIBE` / `UNSUBSCRIBE`
+- `MESSAGE`
+- `DISCONNECT`
+- Heartbeats (both directions)
+
+No transactions, ACK/NACK, or advanced features are used.
+
+## Topic Naming & Purpose
+
+Topics follow a consistent, hierarchical naming scheme:
+
+- `/topic/overview.stats` — Global dashboard metrics and active work summary.
+- `/topic/conversation.{sessionId}.updates` — Per-conversation chat deltas, thoughts, and tool events.
+- `/topic/channel.{channelId}.activity` — Channel activity feed updates (messages, proactive agent updates, proposal events).
+- `/topic/canvas.events` — Inter-agent pipeline and agent status updates.
+- `/topic/approvals.pending` — Court / approvals list updates.
+- `/topic/proposal.{proposalId}.updates` — Individual proposal status and vote changes.
+
+Topic names are stable and versioned implicitly through payload structure.
+
+## Payload Shapes (Target)
+
+All `MESSAGE` frames carry JSON payloads. The following shapes are the target contracts:
+
+### Overview Stats
+```json
+{
+  "type": "overview.stats",
+  "timestamp": "2026-...",
+  "active_agents": { "total": 12, "by_role": {...} },
+  "background_tasks": { "total": 5, "avg_progress": 67 },
+  "pending_proposals": 3
+}
+```
+
+### Conversation Update
+```json
+{
+  "type": "conversation.update",
+  "session_id": "...",
+  "delta": { /* streaming content, thought, or tool event */ },
+  "timestamp": "..."
+}
+```
+
+### Channel Activity
+```json
+{
+  "type": "channel.activity",
+  "channel_id": "...",
+  "event": { /* message, proactive_update, proposal_event, etc. */ },
+  "timestamp": "..."
+}
+```
+
+### Canvas Event
+```json
+{
+  "type": "canvas.event",
+  "agent_id": "...",
+  "task_id": "...",
+  "stage": "Execute",
+  "progress": 45,
+  "timestamp": "..."
+}
+```
+
+Payloads must be small, schema-validated on the server where feasible, and never contain raw secrets or internal addresses.
+
+## Subscription Lifecycle
+
+1. Client connects via WebSocket and sends `CONNECT` (with heartbeat negotiation).
+2. On view mount, client sends `SUBSCRIBE` for relevant topics.
+3. Server maintains a map of `topic → active sessions`.
+4. On relevant internal event, server routes only to matching subscribers.
+5. On view unmount or tab hidden, client sends `UNSUBSCRIBE`.
+6. On disconnect or navigation, server cleans up subscriptions.
+
+Subscriptions are **view-scoped**, not global. The server must enforce cleanup to prevent resource leaks.
+
+## Security & Validation Rules
+
+- All incoming STOMP frames are validated for size, structure, and allowed commands.
+- `SUBSCRIBE` frames are checked against an allow-list of topics the portal is permitted to subscribe to.
+- No client can subscribe to topics belonging to other sessions or channels they do not have access to.
+- `MESSAGE` frames sent to clients are sanitized; sensitive fields are stripped before transmission.
+- Rate limiting is applied per connection and per topic.
+- Heartbeat intervals are negotiated and enforced.
+
+## Fallback to SSE
+
+If STOMP connection fails or is unavailable, the portal gracefully degrades to the existing SSE `/events` endpoint. The same sanitization and access control rules apply.
+
+## Implementation Notes (Go)
+
+- Use a lightweight, self-contained STOMP server (or a minimal wrapper around `golang.org/x/net/websocket` + custom frame handling).
+- Keep the STOMP handler in `internal/dashboard/stomp` with clear separation from template rendering.
+- Subscription manager must be concurrency-safe and support efficient fan-out.
+- All frame processing must happen with strict timeouts and resource limits.
+
+This contract ensures efficient real-time updates while preserving the paranoid security model.

--- a/docs/specs/web-portal/security-boundaries.md
+++ b/docs/specs/web-portal/security-boundaries.md
@@ -1,0 +1,59 @@
+# Security Boundaries & Sanitization Specification
+
+**Status**: Target State
+
+## Overview
+
+Defines security boundaries, input validation, output sanitization, and rate limiting for the Web Portal.
+
+## Core Principles
+
+- Portal is strictly presentation-only.
+- All input from browser is untrusted.
+- All output to browser must be sanitized.
+- High-impact actions require confirmation + rate limiting.
+
+## Input Validation
+
+Multi-layer:
+1. HTTP layer (method, size, content-type)
+2. STOMP frame validation (allow-list, size)
+3. Application-level schema + authorization (via bridge)
+
+## Output Sanitization Rules (Concrete Examples)
+
+### In Single-Agent Traces
+- **Redact**: Raw credentials, API keys, internal IPs/hostnames, file paths outside user scope, large binary blobs, stack traces with internal paths.
+- **Allow**: Tool names, high-level descriptions, sanitized inputs/outputs (e.g., "search query: Zig security model", result summary).
+- **Example**: A tool call that read `/etc/passwd` would show `tool: read_file, path: [REDACTED], result: [REDACTED]`.
+
+### In Chat / Activity Feed
+- Never render raw HTML from agents.
+- Redact any content that looks like secrets or internal system details.
+- Use strict Markdown sanitizer (headings, lists, code, links with allow-list).
+
+### In Proposals & Court Views
+- Diffs are passed through existing git/workspace sanitization.
+- Rationales and comments are shown in full unless they contain sensitive material.
+
+## Rate Limiting
+
+- Per-connection limits on frames/requests.
+- Tighter limits on create proposal, approve/reject, pause/cancel agent.
+- Clear backoff behavior on limit hits.
+
+## Bridge Action Allow-list
+
+Portal may only call a restricted set of actions. High-risk actions must go through Court or confirmation flows.
+
+## Threat Mitigation
+
+- XSS: Strict Markdown + output sanitization.
+- Information Disclosure: Least privilege + aggressive redaction.
+- DoS: Rate limiting + connection cleanup.
+- Privilege Escalation: All actions re-validated on Host + Court where required.
+
+## Implementation Recommendations
+
+- Central `sanitize` package with context-aware rules (trace vs chat vs proposal).
+- Log security events (validation failures, rate limit hits) on the Host for auditability.

--- a/docs/specs/web-portal/single-agent-trace.md
+++ b/docs/specs/web-portal/single-agent-trace.md
@@ -1,0 +1,77 @@
+# Single-Agent Trace View Specification
+
+**Status**: Target State
+
+## Overview
+
+The Single-Agent Trace view provides deep, structured visibility into an individual agent’s reasoning and actions. It is a core observability surface that supports debugging, trust-building, auditing, and understanding why specific decisions were made.
+
+It directly supports the need for clear mental models and progressive trust by making the agent’s ReAct-style loop (Observe → Think → Plan → Act → Judge) transparent and explorable.
+
+## Goals
+
+- Show the full sequence of an agent’s reasoning and tool use in a clean, navigable timeline.
+- Allow expansion of tool calls with sanitized inputs, outputs, and results.
+- Link reasoning steps to broader context (plan, channel, Court proposals).
+- Support real-time streaming when an agent is actively working.
+- Enable intervention from within the trace view when needed.
+
+## Layout
+
+- Header: Agent identity (persona/role), current task/narrow scope, originating channel or plan (with links), and overall status.
+- Main area: Chronological or phase-grouped timeline of the agent’s execution.
+- Side panel: Context summary, memory snippets, and quick actions.
+
+### Timeline / ReAct View
+
+A clean, expandable timeline showing phases such as:
+- Observe
+- Think
+- Plan
+- Act
+- Judge
+
+Each phase entry includes:
+- Timestamp and duration
+- Key output or decision summary
+- Expandable details (especially for Act phases showing tool calls)
+
+**Tool Call Details** (when expanded):
+- Tool name and purpose
+- Sanitized inputs
+- Sanitized outputs or results
+- Duration and success/failure status
+- Links to related artifacts or logs
+
+## Real-Time Behavior
+
+When the agent is active, the trace view streams new phases and tool results in real time via STOMP. The timeline updates live without requiring manual refresh.
+
+## Interaction Patterns
+
+- Expand/collapse individual phases or tool calls.
+- Search or filter within the trace (by phase, tool, keyword).
+- Direct links to:
+  - Originating channel and activity
+  - Related Court proposal (if any)
+  - Full audit log for the session
+- Intervention controls (Pause, Resume, Cancel) with appropriate context and confirmation.
+
+## Edge Cases
+
+- Very long traces: Strong collapsing, search, filtering, and virtual scrolling.
+- Agent idle or completed: Clear final state and links to outcomes (proposal, artifact, etc.).
+- Error states: Prominent but calm error display with relevant context for debugging.
+
+## Persona Considerations
+
+- **Alex Rivera**: Primary surface for building confidence through full transparency of agent reasoning and actions.
+- All personas benefit when debugging unexpected behavior or auditing specific decisions.
+
+## Open Areas
+
+- Exact visual treatment of the timeline (vertical list vs. horizontal stepper vs. grouped phases).
+- How memory context is shown without overwhelming the view.
+- Sanitization rules and display format for tool I/O.
+
+This specification defines the target Single-Agent Trace experience.

--- a/docs/specs/web-portal/test-component.md
+++ b/docs/specs/web-portal/test-component.md
@@ -1,0 +1,41 @@
+# Component & Integration Test Specifications
+
+**Status**: Target State
+
+## Overview
+
+Component and small integration tests sit between unit tests and full E2E. They are useful for validating UI behavior with realistic (but mocked) data without requiring a full running daemon + multiple microVMs.
+
+## Recommended Scope
+
+- Rendering of complex views with mocked events (Canvas, activity feed, traces, pipeline overview).
+- Interaction flows that involve multiple components (e.g., command bar → plan preview → channel transition).
+- State management within a view when receiving real-time events.
+- Error and loading state rendering.
+
+## Example Test Ideas
+
+### Canvas View
+- Render multiple agents in different stages.
+- Verify pipeline progress updates when mock events arrive.
+- Test drill-down from agent card to trace view.
+
+### Activity Feed
+- Verify proactive agent updates appear with correct styling.
+- Test @mention autocomplete behavior.
+- Verify proposal events render with correct status badges.
+
+### Trace View
+- Test expansion of tool calls.
+- Verify sanitization is applied in rendered output.
+- Test navigation from trace back to originating channel.
+
+## Mocking Strategy
+
+- Use test doubles for STOMP events and bridge responses.
+- Provide realistic but controlled data fixtures.
+- Avoid starting real microVMs in these tests.
+
+## Location Suggestion
+
+`internal/dashboard/ui/components/..._test.go` or a dedicated component test directory.

--- a/docs/specs/web-portal/test-contracts.md
+++ b/docs/specs/web-portal/test-contracts.md
@@ -1,0 +1,61 @@
+# Contract Test Specifications
+
+**Status**: Target State
+
+## Overview
+
+Contract tests are the **highest-value** layer for the Web Portal. They verify that the portal correctly produces and consumes the defined contracts with the Host Daemon without requiring a full running system.
+
+## STOMP Contract Tests
+
+### Test: Subscribes to correct topics on view mount
+- When a user opens the Channels view, the portal should subscribe to:
+  - `/topic/channel.{id}.activity`
+  - `/topic/harness.{plan_id}.updates` (if a plan exists)
+- Verify it does **not** subscribe to unrelated topics.
+
+### Test: Parses known payload shapes
+- Send valid payloads for all defined event types.
+- Verify the UI updates correctly (activity feed, pipeline progress, etc.).
+
+### Test: Handles unknown fields gracefully
+- Send a payload with extra unknown fields.
+- Portal should ignore them without error.
+
+### Test: Unsubscribes on view navigation / unmount
+- When navigating away from a channel, verify unsubscription.
+- Verify no memory leaks in subscription manager.
+
+### Test: Falls back to SSE when STOMP unavailable
+- Simulate STOMP connection failure.
+- Verify the portal switches to SSE `/events` and still receives updates.
+
+## Bridge Action Contract Tests
+
+### Test: Only calls allowed actions
+- Create a test double for the bridge client.
+- Perform various UI actions.
+- Assert that only actions in the allow-list are called.
+
+### Test: Correct input shapes for allowed actions
+- For each allowed bridge action, verify the portal sends correctly shaped requests.
+
+### Test: Handles error responses from bridge
+- Simulate bridge returning errors (e.g., permission denied, not found).
+- Verify the portal shows appropriate user-facing error (no internal details leaked).
+
+### Test: High-impact actions require confirmation
+- Actions like "Approve proposal" or "Cancel agent" should not be sent to the bridge until user confirmation.
+
+## Recommended Structure
+
+```
+internal/dashboard/
+├── bridge/
+│   └── client_contract_test.go
+├── stomp/
+│   └── client_contract_test.go
+└── subscription_manager_contract_test.go
+```
+
+Write these tests so they can run quickly in CI without starting microVMs.

--- a/docs/specs/web-portal/test-e2e.md
+++ b/docs/specs/web-portal/test-e2e.md
@@ -1,0 +1,44 @@
+# E2E Test Specifications (Playwright)
+
+**Status**: Target State
+
+## Overview
+
+E2E tests should be kept **minimal** and focused on high-value user journeys that are difficult to validate at lower layers.
+
+## Recommended E2E Tests (Maximum 6–8 total)
+
+1. **Start task from Home**
+   - User enters goal in command bar.
+   - Verify plan preview appears.
+   - Verify transition to channel with visible harness/pipeline state.
+
+2. **Collaborative work with proactive updates**
+   - Agent sends proactive update in channel.
+   - Verify it appears correctly in activity feed.
+
+3. **Full Court review flow**
+   - Proposal appears in Court.
+   - User votes as different personas.
+   - Verify rationales and final decision.
+
+4. **Real-time across tabs**
+   - Open same channel in two tabs.
+   - Make change in one tab.
+   - Verify update appears in second tab.
+
+5. **STOMP disconnect + SSE fallback**
+   - Simulate STOMP failure.
+   - Verify UI continues to receive updates via SSE.
+
+6. **Member management flow**
+   - Invite human and specialist agent.
+   - Verify grouped member list updates correctly.
+   - Remove a member and verify clean state.
+
+## Guidelines
+
+- Use stable `data-testid` attributes.
+- Avoid tests that depend on timing of agent microVM startup.
+- Prefer explicit waits over fixed sleeps.
+- Keep this suite fast enough to run on every significant change.

--- a/docs/specs/web-portal/test-security.md
+++ b/docs/specs/web-portal/test-security.md
@@ -1,0 +1,36 @@
+# Security & Sanitization Test Specifications
+
+**Status**: Target State
+
+## Overview
+
+Security and sanitization tests are critical due to the paranoid security model. These tests should verify that sensitive data never leaks to the browser and that input is properly validated.
+
+## High-Priority Areas
+
+### Output Sanitization
+- Traces: Verify credentials, internal paths, and raw memory are redacted.
+- Chat / Activity Feed: Verify dangerous Markdown or HTML is stripped.
+- Proposals: Verify diffs and artifacts do not leak internal information.
+
+### Input Validation
+- High-impact actions (approve proposal, cancel agent, invite powerful personas) require confirmation.
+- Rate limiting is enforced on sensitive endpoints and STOMP actions.
+- Malformed or oversized input is rejected gracefully.
+
+### Bridge Action Restrictions
+- Portal only calls actions in the documented allow-list.
+- Attempts to call disallowed actions are blocked (and ideally logged on the Host).
+
+### Error Message Hygiene
+- Error messages shown to users never contain stack traces, internal paths, or implementation details.
+
+## Recommended Test Types
+
+- Unit tests for sanitization functions (with concrete examples).
+- Contract tests that verify the portal never sends disallowed bridge actions.
+- E2E spot-checks for critical flows (e.g., viewing a trace after a sensitive tool call).
+
+## Regression Protection
+
+These tests are especially important for catching regressions when new features or agent capabilities are added.

--- a/docs/specs/web-portal/test-specifications-overview.md
+++ b/docs/specs/web-portal/test-specifications-overview.md
@@ -1,0 +1,38 @@
+# Test Specifications Overview
+
+**Status**: Target State
+
+## Purpose
+
+This set of documents provides concrete, actionable test specifications for the Web Portal. The goal is to give implementors (human or AI coding agents) clear guidance on what to test, at what level, and with what focus.
+
+The documents are intentionally split into smaller files to stay within reasonable context windows.
+
+## Document Structure
+
+- `test-specifications-overview.md` — This file. Priorities and how to use the specs.
+- `test-contracts.md` — Contract tests (STOMP + Bridge actions). **Highest priority layer**.
+- `test-unit.md` — Unit test specifications.
+- `test-component.md` — Component and small integration tests.
+- `test-e2e.md` — End-to-end tests (keep minimal).
+
+## Overall Priorities
+
+| Priority | Layer              | Why it matters for this architecture                  | Recommended Volume |
+|----------|--------------------|-------------------------------------------------------|--------------------|
+| High     | Contract Tests     | Catches integration issues without full system        | High               |
+| High     | Unit Tests         | Fast feedback on logic and sanitization               | High               |
+| Medium   | Component Tests    | Validates UI behavior with realistic data             | Medium             |
+| Low      | E2E Tests          | Expensive and harder to keep stable                   | Very Low           |
+
+## How Coding Agents Should Use These Specs
+
+1. Start with **Contract Tests** — they give the best signal for the daemon + microVM model.
+2. Use the examples as patterns. Do not copy them verbatim if the implementation differs slightly.
+3. When in doubt, ask: "Is this testing a contract boundary or pure logic?"
+4. Prefer deterministic tests. Avoid relying on timing of agent microVM startup.
+5. Always consider what should be mocked vs real at each layer (see `testing-strategy.md`).
+
+## Regression Protection Goal
+
+These specifications are designed so that future changes can be validated quickly and reliably. Contract tests in particular should catch breaking changes to payloads or bridge behavior early.

--- a/docs/specs/web-portal/test-unit.md
+++ b/docs/specs/web-portal/test-unit.md
@@ -1,0 +1,30 @@
+# Unit Test Specifications
+
+**Status**: Target State
+
+## Overview
+
+Unit tests should cover pure logic that does not depend on the vsock bridge or real-time infrastructure.
+
+## High-Value Areas
+
+### Sanitization Logic
+- Test that secrets, credentials, and internal paths are redacted in traces.
+- Test that Markdown sanitization removes dangerous content.
+- Test context-aware sanitization (trace vs chat vs proposal).
+
+### Payload Builders / Formatters
+- Test construction of STOMP messages and bridge requests.
+- Test formatting of pipeline stages and progress indicators.
+
+### State Machines / UI Logic (if any)
+- Any pure logic that manages UI state without side effects.
+
+## Anti-Patterns to Avoid
+- Do not put bridge calls or STOMP logic in unit tests.
+- Do not test full page rendering here (use component or E2E tests).
+
+## Recommended Location
+
+`internal/dashboard/sanitize/..._test.go`
+`internal/dashboard/..._test.go` for small pure helpers.

--- a/docs/specs/web-portal/testing-strategy.md
+++ b/docs/specs/web-portal/testing-strategy.md
@@ -1,0 +1,146 @@
+# Web Portal Testing Strategy
+
+**Status**: Target State
+
+## Philosophy
+
+The Web Portal is a **presentation-only** component running in an isolated microVM. It has no business logic, no direct access to the Host Daemon's internals, and communicates exclusively through a narrow vsock bridge.
+
+This architecture creates common confusion for both human developers and coding agents. A good test strategy must:
+
+- Make the boundaries extremely clear.
+- Favor **contract testing** over full integration where possible.
+- Provide reliable, fast feedback loops.
+- Be structured so that an AI coding agent (like Grok Build) can understand what it is allowed to mock vs what must be real.
+
+## Adapted Testing Pyramid for AegisClaw
+
+We use a modified testing pyramid that accounts for the daemon + microVM model:
+
+### 1. Unit Tests (Foundation)
+- **Scope**: Pure functions, sanitization logic, payload builders, UI component rendering logic (where testable).
+- **Location**: `internal/dashboard/..._test.go` and small frontend test utilities.
+- **Speed**: Very fast.
+- **Quantity**: Highest.
+
+**What to test**:
+- Sanitization rules (with concrete examples from `security-boundaries.md`)
+- Payload construction helpers
+- State machines for complex UI interactions (if any)
+- Pure formatting / display logic
+
+**What NOT to test here**:
+- Anything that touches the vsock bridge
+- Real-time behavior
+- Full page rendering (use E2E instead)
+
+### 2. Contract Tests (Critical Layer)
+This is the **most important layer** for the Web Portal.
+
+**Purpose**: Verify that the portal correctly produces and consumes the expected contracts with the Host Daemon, without needing a full running system.
+
+**Types**:
+
+#### A. STOMP Contract Tests
+- Verify that the portal correctly subscribes to expected topics.
+- Verify that it can parse all defined payload shapes (see `real-time-contracts.md`).
+- Verify graceful handling of unknown fields (forward compatibility).
+- Verify proper cleanup on unsubscription / disconnect.
+
+#### B. Bridge Action Contract Tests
+- Define the exact allow-list of actions the portal may call.
+- Test that the portal only calls allowed actions.
+- Test input/output shapes for each allowed action.
+- Use mocks or test doubles for the bridge client.
+
+**Why this layer is critical**:
+- Catches most integration issues without the complexity of full E2E.
+- Much faster and more reliable than trying to spin up multiple microVMs.
+- Gives coding agents a clear boundary: "You can mock the bridge here."
+
+### 3. Component / Integration Tests
+- Test individual UI components or small groups of components with realistic data.
+- Can use a test harness that provides fake STOMP events or bridge responses.
+- Good for testing rendering of complex views (Canvas, traces, activity feeds).
+
+### 4. E2E Tests (Playwright) – The Tip
+
+Use sparingly but strategically.
+
+**High-value E2E tests** (keep this set small and reliable):
+- Major user journeys that cross multiple boundaries
+- Real-time behavior that is difficult to test at lower levels
+- End-to-end governance flows (proposal → Court → decision)
+
+**Recommended E2E scope**:
+- Start a task from Home → see plan decomposition → channel created with visible harness state.
+- Collaborative work with proactive agent updates appearing in the feed.
+- Full Court review flow (vote, see rationales, approve).
+- Real-time updates across multiple tabs.
+- STOMP disconnect + fallback to SSE.
+
+**What to avoid in E2E**:
+- Testing every UI state
+- Testing internal sanitization logic (use contract/unit tests)
+- Flaky tests that depend on timing of agent microVMs
+
+## Helping Coding Agents Understand the Architecture
+
+Coding agents frequently get confused by the daemon + microVM model. The test strategy should include explicit guidance:
+
+### Clear Boundaries (Document These)
+
+- The **Portal** only renders UI and sends/receives messages over the bridge.
+- The **Host Daemon** owns all business logic, agent orchestration, and governance.
+- Agent microVMs are separate from the Portal microVM.
+- The portal **never** directly controls agents or runs business logic.
+
+### Recommended Test Double Strategy
+
+| Layer                    | What to Mock                  | What Should Be Real          | Notes for Agents                     |
+|--------------------------|-------------------------------|------------------------------|--------------------------------------|
+| Unit Tests               | Everything external           | Pure logic                   | Very safe to mock                    |
+| Contract Tests           | vsock bridge client           | Contract shapes              | Best place to catch integration bugs |
+| Component Tests          | STOMP events + bridge         | Rendering logic              | Good for UI behavior                 |
+| E2E Tests                | As little as possible         | Full flow (with test setup)  | Use sparingly and keep stable        |
+
+### Naming Conventions (Helpful for Agents)
+
+- `*_contract_test.go` → Contract tests against bridge/STOMP
+- `*_component_test.go` → Component rendering tests
+- `e2e_*.spec.ts` → Playwright end-to-end tests
+- Use clear comments at the top of test files explaining the architecture boundary being tested.
+
+## Recommended Test Organization
+
+```
+internal/dashboard/
+├── sanitize/
+│   └── sanitize_test.go          # Unit tests
+├── stomp/
+│   ├── client_test.go            # STOMP contract tests
+│   └── subscription_manager_test.go
+├── bridge/
+│   └── client_contract_test.go   # Bridge action contracts
+├── ui/
+│   └── components/               # Component tests
+└── testutil/
+    └── fake_bridge.go
+    └── fake_stomp.go
+```
+
+## Stability & Reliability Goals
+
+- All tests should be deterministic.
+- E2E tests should use explicit waits and stable selectors (`data-testid`).
+- Avoid timing-dependent tests involving agent microVM spin-up.
+- Use test fixtures and factories for realistic but controlled data.
+
+## How This Strategy Helps Grok Build / Coding Agents
+
+- Clear layering tells the agent exactly what level of fidelity is needed.
+- Contract tests give fast, reliable feedback without needing a full daemon + multiple VMs.
+- Explicit guidance on what to mock reduces hallucinations about the architecture.
+- The pyramid structure naturally pushes complex logic down to faster, more reliable test layers.
+
+This strategy is designed to maximize confidence while minimizing flakiness and confusion.

--- a/docs/specs/web-portal/web-portal.md
+++ b/docs/specs/web-portal/web-portal.md
@@ -1,0 +1,261 @@
+# Web Portal Specification
+
+**Status**: Target State  
+**Owner**: AegisClaw Team  
+
+## Overview
+
+The AegisClaw Web Portal is the primary rich, real-time web interface for users, reviewers, and operators. It provides visibility, interaction, and control across collaboration, governance, agent activity, and system state.
+
+The portal runs in a dedicated isolated Web Portal VM and communicates exclusively through a trusted vsock API bridge to the Host Daemon. It is strictly presentation-only: no business logic, no persistent state, and no secrets reside in the portal.
+
+The design makes the system's core harness visible and actionable:
+- PM-orchestrated decomposition of goals into narrow-scope tasks for specialist agents.
+- Parallel execution of those tasks across isolated microVMs.
+- Adversarial multi-persona review through the Court.
+- Structured pipeline stages with full observability and feedback loops.
+
+This creates a calm, immediately productive command center that feels both powerful and trustworthy.
+
+## Design Principles
+
+1. **Immediate Productivity** — Users who know what they want can act instantly via a prominent command surface. Others receive gentle, contextual, dismissible guidance.
+2. **Harness Visibility** — The decomposition into narrow tasks, parallel agent work, adversarial Court review, and pipeline stages are first-class, scannable elements in the interface.
+3. **Low-Friction Collaboration** — Channels function like lightweight, scannable workspaces. Member management is focused and grouped by role. Activity feeds prioritize decisions and progress over noise.
+4. **Progressive Trust & Disclosure** — The interface starts conservative and reveals depth (traces, rationales, controls) as users engage. Defaults are persona-aware. Reasoning steps are shown while agents are actively working and collapsed intelligently once decisive results appear.
+5. **Clear Mental Model** — Users always understand what agents are doing, what capabilities exist, and what a new action requires in terms of governance.
+6. **Paranoid Transparency without Overwhelm** — Security posture, isolation guarantees, and governance status are calm, persistent, and non-alarming. Reasoning visibility follows a Progressive default that balances transparency with scannability and token efficiency.
+7. **Efficient Real-Time Observability** — Targeted updates via STOMP topic subscriptions deliver responsiveness without excessive network or compute cost.
+8. **Metrics Belong on the Dashboard** — The primary Home surface stays focused on action and relevant context. Global metrics and monitoring live on the Dashboard.
+
+## Personas & Supported Journeys
+
+The portal supports the following primary personas:
+
+- **Alex Rivera** (Security-Conscious Solo Hobbyist) — Requires strong visibility into single-agent traces, plain-English Court rationales, easy deferral, and the feeling of personal sign-off on governance decisions.
+- **Jordan Hale** (Indie Developer / Small-Team Founder) — Needs rapid iteration with exportable, investor-grade audit trails from the Court and the ability to simulate stricter review modes.
+- **Sam Chen** (Mid-Market Tech Lead) — Needs team-wide oversight of multiple channels and agents, shared governance history, and velocity without requiring extra governance staff.
+- **Dr. Lena Moreau** (Enterprise CISO) — Needs policy injection, consistent governance across instances, structured exports (SBOM, regulatory mapping), and a single framework that scales from laptop to production.
+
+Key journeys supported:
+- Starting a new task or conversation.
+- Collaborative task execution with proactive agent updates and human intervention.
+- Monitoring agent activity with drill-down and intervention.
+- Reviewing and acting on Court decisions.
+- Creating and iterating on skills under governance.
+- Multi-agent team workflows.
+
+## Information Architecture
+
+**Primary Navigation**:
+Home | Channels | Dashboard | Court | Agents | Skills | Audit | Settings
+
+**Persistent Elements**:
+- Top header with logo, system status, connection indicator, notifications, and operator menu.
+- Collapsible right context panel (Operator / Channel / Security Posture + Harness overview). On mobile this becomes a bottom sheet triggered from header or floating action.
+- Left sidebar with quick navigation, recent channels, and quick actions.
+
+**Responsive Behaviour**:
+Desktop uses the three-zone layout. Mobile prioritises a bottom navigation (Channels | Dashboard | Court | More) with contextual bottom sheets for member management, harness details, and operator controls. Channels on mobile includes a lightweight persistent command affordance and Agent Activity Summary.
+
+## Home (Productive Command Center)
+
+Home is the primary entry point and productivity surface.
+
+**Purpose**:
+Allow users who know their intent to act immediately while providing relevant, non-intrusive context and suggestions for others.
+
+**Key Elements**:
+- **Prominent Command Bar** — Large, always-visible input for natural language goals. Subtle helper text explains that the PM will decompose the goal into narrow tasks for specialists with Court review. Submission triggers a plan preview then transitions to the relevant Channel or Canvas.
+- **Contextual Suggestions** — Dismissible or collapsible cards showing relevant next actions based on recent channel activity or opted-in external signals. Never obstruct the command bar. Toggleable to control token usage.
+- **Quick Starts** (for blank slate or first-time users) — Optional, helpful entry points such as "Research a topic", "Start a feature channel", "Audit security posture", or "Propose a custom skill".
+- **Subtle Live Pulse** — Minimal, non-dominant row showing active agents (by role), pending proposals, and background task progress. Clickable to Dashboard.
+- **Recent Activity Preview** — Small number of scannable items with direct links to Channels, traces, or proposals.
+- **Agent Activity Summary** (desktop) — Lightweight chips or cards showing currently active narrow tasks/personas and token usage when exposed.
+
+**Right Context Panel**:
+Security posture summary, operator controls (Safe Mode, autonomy level), and a "Harness view" teaser that links to deeper pipeline visibility.
+
+**Behavior**:
+Real-time updates for active counts and recent activity via STOMP. New users see stronger quick-start emphasis; experienced users with active work see more contextual suggestions.
+
+## Channels (Collaborative Workspaces)
+
+Channels are the primary collaborative workspaces where humans and agents work together on scoped goals.
+
+**Purpose**:
+Provide a focused, low-noise environment for inter-agent collaboration, human intervention, and embedded governance.
+
+**Layout**:
+Three-zone desktop structure. On mobile the right context panel collapses to a bottom sheet; the main area includes a persistent quick-command affordance and Agent Activity Summary.
+
+**Harness / Pipeline Overview**:
+A prominent but calm section (strip or card group) that shows:
+- The current high-level plan or goal.
+- Decomposition into narrow-scope tasks with assigned specialist personas.
+- Progress and status per task/stage.
+- Visible pipeline stages: Plan → Delegate → Execute → Propose → Court Review → Apply.
+
+This section makes the parallel narrow work and governance path immediately understandable.
+
+**Activity Feed**:
+Real-time feed of human messages, proactive agent updates, tool calls, inter-agent hand-offs, and proposal events. Threads keep focused discussion clean. @mention autocomplete supports both humans and agent roles/personas. Proactive updates are visually distinct. Streaming support for live agent output.
+
+**Reasoning Visibility (Progressive default)**:
+- Live/in-flight agent reasoning steps are expanded and highlighted.
+- Once a decisive result or proposal appears, reasoning collapses to a compact one-line summary with a "Show reasoning" affordance.
+- Human messages and Court decisions remain expanded.
+- Feed-level controls ("Collapse all reasoning", "Expand recent") manage density, especially on mobile.
+- Policy presets (Progressive / Paranoid / Velocity) are available globally and per-channel.
+
+**Quick Input**:
+Natural language input with @mention support. High-privilege or high-risk actions trigger clear approval prompts.
+
+**Grouped Member Management**:
+Focused, searchable pane or modal with collapsible sections:
+- **Core Court** (the seven personas with role, last activity/vote, and "View trace" links).
+- **Project / SDLC Roles** (unique project-manager and specialists with status).
+- **Humans / Operators** (current user and collaborators with easy add/remove).
+
+No flat, overwhelming lists of every persona. Management actions (invite, remove, view trace) are role-aware and low-friction.
+
+**Real-time**:
+Per-channel STOMP topics for activity, member status changes, and proposal updates.
+
+## Dashboard & Monitoring
+
+The Dashboard provides global visibility and control over active work.
+
+**Purpose**:
+Give operators and leads an at-a-glance view of everything running across channels, with quick drill-down and intervention capabilities.
+
+**Key Sections**:
+- Filterable search and view toggles (All, By Channel, By Persona, Background only).
+- Metrics row: Active Agents (with role breakdown), Background Tasks (count + average progress), Pending Proposals (count + urgency).
+- Active Work lists or cards: Each item shows narrow scope/task, assigned persona(s), current stage/progress, last update, and originating channel. Clicking drills into Single-Agent Trace, Canvas, or Court detail.
+- Live global activity stream (filterable).
+- Intervention controls (Pause / Resume / Cancel) with appropriate confirmation for high-impact actions.
+- Harness health indicators and aggregate security posture.
+- Agent Activity Summary (global view).
+
+**Real-time**:
+Strong use of STOMP subscriptions for stats, task progress, and new proposals.
+
+## Court / Governance Hub
+
+Court is the dedicated surface for reviewing and acting on governance decisions.
+
+**Purpose**:
+Make adversarial multi-persona review transparent, actionable, and exportable.
+
+**Features**:
+- Filterable list of proposals (status, originating channel, vote summary, security gate results, age).
+- Detail view showing structured pipeline stages reached, per-persona vote cards with short rationales and timestamps, diffs/artifacts, and security scan results.
+- Clear actions: Approve, Reject, Defer (with optional note), Comment. Batch actions supported where appropriate.
+- Prominent export options for structured reports, SBOMs, and regulatory mappings (critical for compliance and diligence needs). Quick export actions are also available from completed proposals in Channels and Court lists.
+- Direct links back to the originating Channel or Canvas.
+
+**Real-time**:
+Live updates when votes arrive or new proposals appear.
+
+## Canvas (Inter-Agent Pipeline View)
+
+Canvas provides a visual workspace for watching multiple agents collaborate on a goal.
+
+**Purpose**:
+Make parallel narrow-scope work and hand-offs visible and understandable at a glance.
+
+**Features**:
+- Grid or card layout of active agents/roles showing their assigned narrow task, status, and progress.
+- Visual pipeline or timeline representation of stages and dependencies.
+- Shared artifacts panel (research notes, diffs, plans).
+- Easy drill-down to Single-Agent Trace, originating Channel, or pending Court proposal.
+- Real-time updates via dedicated STOMP topics.
+- Low-friction entry from the Compact Harness strip in Channels and Home.
+
+## Single-Agent Trace View
+
+The trace view gives deep, actionable visibility into an individual agent's reasoning and actions.
+
+**Purpose**:
+Support debugging, trust-building, and detailed understanding of agent behavior.
+
+**Features**:
+- Clean ReAct-style timeline (Observe → Think → Plan → Act → Judge).
+- Expandable details per phase including sanitized tool inputs/outputs, duration, success/failure, and relevant memory context.
+- Links to originating task/plan, channel, and any related Court proposal.
+- Real-time streaming when the agent is active.
+- Intervention controls (Pause / Resume / Cancel) with context.
+- Direct link to full audit log for the session.
+
+**Behavior**:
+Long traces support good collapsing, search, and filtering. This view is especially valuable for building confidence in agent actions and for detailed auditing.
+
+## Reasoning Visibility & Progressive Disclosure
+
+**Default Behaviour (Progressive policy)**
+
+- While an agent is actively working on a narrow task, current reasoning steps (Observe → Think → Plan → Act, tool calls) are expanded and highlighted for live observability.
+- Once a decisive result, proposal, or stage transition occurs, intermediate reasoning automatically collapses to a compact one-line summary (e.g. "Researcher completed scope with 3 tool calls") with a clear "Show reasoning" affordance.
+- Human messages and Court decisions remain fully expanded.
+
+**Policy Model**
+
+Named presets available globally and per-channel:
+- **Progressive** (recommended default): live expanded, post-decision collapsed.
+- **Paranoid / Maximum Visibility**: all reasoning remains expanded by default.
+- **Velocity / Minimal Noise**: reasoning collapsed by default except for live in-flight steps.
+
+Enterprise policy can lock the chosen preset. This model balances the paranoid transparency promise with practical scannability and token efficiency for velocity-focused users (Jordan, Sam) while giving Alex and Lena easy access to full depth.
+
+**Mobile Presentation**
+
+On mobile the same Progressive rules apply. Completed reasoning defaults collapsed. A feed-level control for collapsing/expanding reasoning is available in the Channel header or feed menu to manage density on small screens.
+
+**Agent Activity Summary Component**
+
+A lightweight, reusable component that surfaces:
+- Currently active narrow tasks and assigned personas
+- Overall stage progress
+- Token usage or activity cost (when the backend safely exposes it)
+
+It appears in Home (desktop), the Channels header area (desktop and mobile), and Dashboard. It gives at-a-glance visibility into "what work is happening and what resources it is consuming" without duplicating full harness details or the Dashboard. This directly supports Jordan and Sam’s need to monitor token spend and Alex/Lena’s need for transparency.
+
+## Real-Time Architecture
+
+The portal uses targeted STOMP-over-WebSocket topic subscriptions for efficient, view-specific updates. This replaces indiscriminate global SSE bundles for most screens while maintaining graceful fallback.
+
+Key topics include:
+- Per-conversation updates for Chat.
+- Per-channel activity and proposal updates.
+- Canvas events.
+- Overview / Dashboard statistics.
+- Approvals / Court pending.
+
+Subscriptions are managed on view mount/unmount. The implementation remains minimal, self-contained, and consistent with the paranoid security model (frame validation, size/rate limits, no secret exposure).
+
+## Security & Isolation Model
+
+The Web Portal VM is strictly isolated. All actions are mediated through the vsock bridge. The browser has no direct access to secrets, external resources, or unvalidated actions. Security posture indicators ("Browser isolated", "Stable selectors", "No external resources") are calm and persistent. All governance-relevant changes flow through the Court with full auditability.
+
+## Open Areas for Further Specification
+
+- Exact component library and design tokens.
+- Detailed payload shapes for all STOMP topics.
+- Interaction states and loading behaviors for the harness pipeline visualization.
+- Member management modal vs inline pane patterns.
+- Export formats and compliance mapping details.
+- Full E2E test coverage matrix for the new flows.
+- Detailed interaction patterns for the Agent Activity Summary component and Progressive reasoning collapsing.
+
+These areas will be expanded in focused follow-on specification documents within this folder.
+
+## Related Documents
+
+- `docs/prd/personas.md` and `docs/prd/user-personas.md`
+- `docs/prd/collaboration-model.md`
+- `docs/specs/user-journeys/` (particularly collaborative task execution, monitoring, and Court review journeys)
+- `docs/specs/web-portal-vm.md`
+- `docs/specs/event-system.md`
+
+This specification defines the target experience. Implementation should align to these behaviors and interaction patterns.


### PR DESCRIPTION
## Summary

This PR adds the complete target-state Web Portal specification set under `docs/specs/web-portal/`.

These are the **authoritative specifications that PR #72 was implemented against**. The portal implementation merged via #72 into `feat/web-portal-specs`; this PR lands the documentation on `main` as a focused, docs-only changeset.

## Scope

**Documentation only** — 22 files under `docs/specs/web-portal/`, no implementation changes.

## What's included

### Core portal vision & pages
- `web-portal.md` — overall target-state portal specification
- `channels.md`, `dashboard.md`, `court.md`, `canvas.md`, `single-agent-trace.md` — per-view specs

### Implementation-focused documents
- `real-time-contracts.md` — STOMP topic subscriptions and payload shapes
- `security-boundaries.md` — sanitization rules and input validation
- `harness-pipeline-data-model.md` — plan/task/stage data model and events
- `member-management-flow.md`, `onboarding-and-suggestions.md`, `export-formats.md`
- `design-tokens-and-components.md` — canonical design tokens and component patterns
- `performance-targets.md`, `implementation-gaps-and-priorities.md`

### Testing strategy
- `testing-strategy.md` — adapted testing pyramid for daemon + microVM architecture
- `test-specifications-overview.md` plus focused `test-*.md` files (contracts, unit, component, e2e, security)

## Key refinements (latest from `feat/web-portal-specs`)

- **Progressive reasoning visibility** — live expanded, post-decision collapsed; feed-level controls
- **Agent Activity Summary** — lightweight active-work chips in Home, Channels, and Dashboard
- **Mobile patterns** — bottom navigation, bottom sheets for context, responsive layout rules
- **Policy presets** — Progressive / Paranoid / Velocity (global and per-channel)

## Relationship to PR #71

PR #71 (`feat/web-portal-specs`) accumulated the full #72 implementation on the same branch (206 files). This PR supersedes #71 with a **focused docs-only** changeset. **Close #71** once this merges.

## Checklist

- [x] Specs sourced from `feat/web-portal-specs` (latest refinements)
- [x] Only `docs/specs/web-portal/` changed
- [x] No code or build changes