### PR TITLE
feat(web-portal): address Issue #73 deferred items

### DIFF
--- a/cmd/web-portal/static/index.html
+++ b/cmd/web-portal/static/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>AegisClaw Secure Command Center</title>
-    <script type="module" crossorigin src="/assets/index-Dw3K5QHs.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BWQB8vV_.css">
+    <script type="module" crossorigin src="/assets/index-ZZBtVPbd.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-RHGgF4m6.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/dashboard/goals_api.go
+++ b/internal/dashboard/goals_api.go
@@ -56,6 +56,21 @@ func (s *Server) handleAPIGoals(w http.ResponseWriter, r *http.Request) {
 		Stages:    stages,
 	}
 	s.stompPublisher().PublishHarness(planID, channelID, event)
+	s.harnessMu.Lock()
+	if s.harnessCache == nil {
+		s.harnessCache = make(map[string]contracts.HarnessState)
+	}
+	s.harnessCache[channelID] = contracts.HarnessState{
+		Plan: &contracts.Plan{
+			PlanID:    planID,
+			ChannelID: channelID,
+			Goal:      req.Goal,
+			Status:    contracts.PlanStatusActive,
+			Stages:    stages,
+		},
+		Tasks: []contracts.NarrowTask{},
+	}
+	s.harnessMu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck

--- a/internal/dashboard/harness_delta.go
+++ b/internal/dashboard/harness_delta.go
@@ -1,0 +1,100 @@
+package dashboard
+
+import (
+	"context"
+
+	"AegisClaw/internal/dashboard/contracts"
+)
+
+// publishHarnessDeltas compares fresh harness state with the last snapshot for a
+// channel and emits structured harness.* STOMP events (per harness-pipeline-data-model.md).
+func (s *Server) publishHarnessDeltas(ctx context.Context, channelID string) {
+	if channelID == "" {
+		return
+	}
+	state := s.collectHarnessState(ctx, channelID)
+	planID := "plan_" + channelID
+	if state.Plan != nil && state.Plan.PlanID != "" {
+		planID = state.Plan.PlanID
+	}
+
+	s.harnessMu.Lock()
+	if s.harnessCache == nil {
+		s.harnessCache = make(map[string]contracts.HarnessState)
+	}
+	prev, hadPrev := s.harnessCache[channelID]
+	s.harnessCache[channelID] = state
+	s.harnessMu.Unlock()
+
+	pub := s.stompPublisher()
+
+	if state.Plan != nil && state.Plan.Goal != "" {
+		emitPlan := !hadPrev || prev.Plan == nil || prev.Plan.Goal != state.Plan.Goal
+		if emitPlan {
+			pub.PublishHarness(planID, channelID, contracts.HarnessPlanCreated{
+				Type:      contracts.TypeHarnessPlanCreated,
+				PlanID:    planID,
+				ChannelID: channelID,
+				Goal:      state.Plan.Goal,
+				Stages:    state.Plan.Stages,
+			})
+		} else if hadPrev && prev.Plan != nil {
+			for i, stage := range state.Plan.Stages {
+				if i >= len(prev.Plan.Stages) {
+					break
+				}
+				if stage.Status != prev.Plan.Stages[i].Status {
+					pub.PublishHarness(planID, channelID, contracts.HarnessStageTransition{
+						Type:   contracts.TypeHarnessStageTrans,
+						PlanID: planID,
+						Stage:  stage.Name,
+						Status: stage.Status,
+					})
+				}
+			}
+		}
+	}
+
+	prevTasks := map[string]contracts.NarrowTask{}
+	if hadPrev {
+		for _, t := range prev.Tasks {
+			prevTasks[t.TaskID] = t
+		}
+	}
+	for _, task := range state.Tasks {
+		prevTask, existed := prevTasks[task.TaskID]
+		if !existed {
+			pub.PublishHarness(planID, channelID, contracts.HarnessTaskAssigned{
+				Type:         contracts.TypeHarnessTaskAssigned,
+				TaskID:       task.TaskID,
+				PlanID:       planID,
+				AgentPersona: task.AgentPersona,
+				Scope:        task.Scope,
+				CurrentStage: task.CurrentStage,
+			})
+			continue
+		}
+		if task.Progress != prevTask.Progress ||
+			task.CurrentStage != prevTask.CurrentStage ||
+			task.Scope != prevTask.Scope {
+			summary := task.Scope
+			if task.Progress > prevTask.Progress {
+				summary = progressSummary(task)
+			}
+			pub.PublishHarness(planID, channelID, contracts.HarnessTaskProgress{
+				Type:         contracts.TypeHarnessTaskProgress,
+				TaskID:       task.TaskID,
+				Progress:     task.Progress,
+				CurrentStage: task.CurrentStage,
+				Summary:      summary,
+			})
+		}
+	}
+}
+
+func progressSummary(task contracts.NarrowTask) string {
+	if task.Scope != "" {
+		return task.Scope
+	}
+	return "Task progress updated"
+}

--- a/internal/dashboard/harness_delta_test.go
+++ b/internal/dashboard/harness_delta_test.go
@@ -1,0 +1,97 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"AegisClaw/internal/dashboard/contracts"
+	"AegisClaw/internal/portalstomp"
+)
+
+type harnessMockClient struct {
+	state contracts.HarnessState
+}
+
+func (m *harnessMockClient) Call(_ context.Context, action string, _ json.RawMessage) (*APIResponse, error) {
+	if action != "harness.get" {
+		return &APIResponse{Success: true}, nil
+	}
+	body, _ := json.Marshal(m.state)
+	return &APIResponse{Success: true, Data: body}, nil
+}
+
+func TestPublishHarnessDeltasEmitsStructuredEvents(t *testing.T) {
+	hub := portalstomp.NewHub()
+	sess := portalstomp.NewSession(hub)
+	sess.HandleFrame("SUBSCRIBE", map[string]string{
+		"id":          "sub-harness",
+		"destination": contracts.HarnessUpdatesTopic("plan_main"),
+	}, "")
+
+	s := &Server{
+		stompHub: hub,
+		apiClient: &harnessMockClient{
+			state: contracts.HarnessState{
+				Plan: &contracts.Plan{
+					PlanID:    "plan_main",
+					ChannelID: "main",
+					Goal:      "Compare Zig vs Rust",
+					Stages:    contracts.DefaultStages(),
+				},
+				Tasks: []contracts.NarrowTask{
+					{
+						TaskID:       "task_1",
+						PlanID:       "plan_main",
+						AgentPersona: "researcher",
+						Scope:        "Research Zig",
+						CurrentStage: "Execute",
+						Progress:     10,
+					},
+				},
+			},
+		},
+	}
+
+	s.publishHarnessDeltas(context.Background(), "main")
+
+	var types []string
+	for i := 0; i < 4; i++ {
+		select {
+		case frame := <-sess.Outbound():
+			if !strings.Contains(frame, "MESSAGE") {
+				continue
+			}
+			idx := strings.Index(frame, "\n\n")
+			if idx < 0 {
+				continue
+			}
+			body := frame[idx+2:]
+			body = strings.TrimSuffix(body, "\x00")
+			var m map[string]interface{}
+			if json.Unmarshal([]byte(body), &m) == nil {
+				if typ, _ := m["type"].(string); typ != "" {
+					types = append(types, typ)
+				}
+			}
+		default:
+			break
+		}
+	}
+
+	has := func(want string) bool {
+		for _, t := range types {
+			if t == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(contracts.TypeHarnessPlanCreated) {
+		t.Fatalf("missing plan created, got %v", types)
+	}
+	if !has(contracts.TypeHarnessTaskAssigned) {
+		t.Fatalf("missing task assigned, got %v", types)
+	}
+}

--- a/internal/dashboard/portal_extended_api.go
+++ b/internal/dashboard/portal_extended_api.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"AegisClaw/internal/dashboard/contracts"
+	"AegisClaw/internal/dashboard/ratelimit"
 	"AegisClaw/internal/dashboard/sanitize"
 )
 
@@ -120,6 +121,9 @@ func (s *Server) handleAPIAgentDetail(w http.ResponseWriter, r *http.Request) {
 		case "pause", "resume", "cancel":
 			if r.Method != http.MethodPost {
 				http.Error(w, "POST required", http.StatusMethodNotAllowed)
+				return
+			}
+			if !ratelimit.Guard(w, r, ratelimit.CategoryAgentControl) {
 				return
 			}
 			action := "agent." + parts[1]
@@ -245,6 +249,9 @@ func (s *Server) handleAPISecurityPosture(w http.ResponseWriter, r *http.Request
 func (s *Server) handleProposalAction(w http.ResponseWriter, r *http.Request, proposalID, action string) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	if !ratelimit.Guard(w, r, ratelimit.CategoryProposalAction) {
 		return
 	}
 	bridgeAction := "proposal." + action

--- a/internal/dashboard/ratelimit/limiter.go
+++ b/internal/dashboard/ratelimit/limiter.go
@@ -1,0 +1,112 @@
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Category identifies a rate-limit bucket per security-boundaries.md.
+type Category string
+
+const (
+	CategoryProposalAction Category = "proposal_action"
+	CategoryAgentControl   Category = "agent_control"
+	CategoryMemberRemove   Category = "member_remove"
+	CategoryChannelArchive Category = "channel_archive"
+)
+
+// Limits per category: max requests per window.
+var limits = map[Category]struct {
+	Max    int
+	Window time.Duration
+}{
+	CategoryProposalAction: {Max: 12, Window: time.Minute},
+	CategoryAgentControl:   {Max: 24, Window: time.Minute},
+	CategoryMemberRemove:   {Max: 10, Window: time.Minute},
+	CategoryChannelArchive: {Max: 6, Window: time.Minute},
+}
+
+type bucket struct {
+	tokens     int
+	lastRefill time.Time
+	max        int
+	window     time.Duration
+}
+
+// Limiter provides per-client, per-category token-bucket rate limiting.
+type Limiter struct {
+	mu      sync.Mutex
+	buckets map[string]*bucket
+}
+
+// Default is the shared portal API rate limiter.
+var Default = &Limiter{buckets: make(map[string]*bucket)}
+
+// Allow reports whether the client may perform an action in category.
+func (l *Limiter) Allow(clientKey string, cat Category) bool {
+	cfg, ok := limits[cat]
+	if !ok || clientKey == "" {
+		return true
+	}
+	key := clientKey + ":" + string(cat)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: cfg.Max, lastRefill: time.Now().UTC(), max: cfg.Max, window: cfg.Window}
+		l.buckets[key] = b
+	}
+	now := time.Now().UTC()
+	elapsed := now.Sub(b.lastRefill)
+	if elapsed >= b.window {
+		refills := int(elapsed / b.window)
+		if refills > 0 {
+			b.tokens += refills * b.max
+			if b.tokens > b.max {
+				b.tokens = b.max
+			}
+			b.lastRefill = now
+		}
+	}
+	if b.tokens <= 0 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// ClientKey extracts a stable per-request client identifier (IP).
+func ClientKey(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); xff != "" {
+		parts := strings.Split(xff, ",")
+		return strings.TrimSpace(parts[0])
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// WriteTooManyRequests sets standard 429 response headers.
+func WriteTooManyRequests(w http.ResponseWriter) {
+	w.Header().Set("Retry-After", "60")
+	http.Error(w, "rate limited", http.StatusTooManyRequests)
+}
+
+// Guard returns false and writes 429 when the limit is exceeded.
+func Guard(w http.ResponseWriter, r *http.Request, cat Category) bool {
+	if Default.Allow(ClientKey(r), cat) {
+		return true
+	}
+	WriteTooManyRequests(w)
+	return false
+}

--- a/internal/dashboard/ratelimit/limiter_test.go
+++ b/internal/dashboard/ratelimit/limiter_test.go
@@ -1,0 +1,37 @@
+package ratelimit
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLimiterBlocksAfterMax(t *testing.T) {
+	l := &Limiter{buckets: make(map[string]*bucket)}
+	key := "127.0.0.1"
+	for i := 0; i < 12; i++ {
+		if !l.Allow(key, CategoryProposalAction) {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+	if l.Allow(key, CategoryProposalAction) {
+		t.Fatal("13th request should be rate limited")
+	}
+}
+
+func TestGuardWrites429(t *testing.T) {
+	l := &Limiter{buckets: make(map[string]*bucket)}
+	Default = l
+	req := httptest.NewRequest("POST", "/api/proposals/p1/approve", nil)
+	req.RemoteAddr = "203.0.113.1:1234"
+	w := httptest.NewRecorder()
+	for i := 0; i < 12; i++ {
+		_ = Guard(w, req, CategoryProposalAction)
+	}
+	w2 := httptest.NewRecorder()
+	if Guard(w2, req, CategoryProposalAction) {
+		t.Fatal("expected rate limit")
+	}
+	if w2.Code != 429 {
+		t.Fatalf("got %d, want 429", w2.Code)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"AegisClaw/internal/dashboard/contracts"
 	"AegisClaw/internal/dashboard/sanitize"
 	"AegisClaw/internal/portalstomp"
 	"context"
@@ -9,6 +10,7 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,6 +21,9 @@ type Server struct {
 	funcMap   template.FuncMap
 	mux       *http.ServeMux
 	stompHub  *portalstomp.Hub
+
+	harnessMu    sync.Mutex
+	harnessCache map[string]contracts.HarnessState
 }
 
 // APIClient abstracts daemon API calls for the dashboard.

--- a/internal/dashboard/spa_api.go
+++ b/internal/dashboard/spa_api.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"AegisClaw/internal/dashboard/ratelimit"
 	"AegisClaw/internal/dashboard/realtime"
 	"AegisClaw/internal/dashboard/sanitize"
 	"AegisClaw/internal/collab"
@@ -65,6 +66,11 @@ func (s *Server) handleInternalChannelActivitySTOMP(w http.ResponseWriter, r *ht
 	}
 	collab.Tracef("web-portal", "stomp.notify.recv", "ch=%s from=%s", req.ChannelID, req.From)
 	s.PublishChannelSTOMP(req.ChannelID, req.From, req.Content)
+	go func(chID string) {
+		ctx, cancel := context.WithTimeout(context.Background(), spaAPITimeout)
+		defer cancel()
+		s.publishHarnessDeltas(ctx, chID)
+	}(req.ChannelID)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -180,6 +186,9 @@ func (s *Server) handleAPIChannels(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(state) //nolint:errcheck
 
 	case len(parts) == 2 && parts[1] == "archive" && r.Method == http.MethodPost:
+		if !ratelimit.Guard(w, r, ratelimit.CategoryChannelArchive) {
+			return
+		}
 		if bridgeGuard.NeedsConfirmation("channel.archive") && r.Header.Get("X-Aegis-Confirmed") != "1" {
 			http.Error(w, "confirmation required", http.StatusPreconditionRequired)
 			return
@@ -202,6 +211,9 @@ func (s *Server) handleAPIChannels(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{"ok": true}) //nolint:errcheck
 
 	case len(parts) == 3 && parts[1] == "members" && parts[2] == "remove" && r.Method == http.MethodPost:
+		if !ratelimit.Guard(w, r, ratelimit.CategoryMemberRemove) {
+			return
+		}
 		if bridgeGuard.NeedsConfirmation("channel.remove_member") && r.Header.Get("X-Aegis-Confirmed") != "1" {
 			http.Error(w, "confirmation required", http.StatusPreconditionRequired)
 			return

--- a/web-portal/src/components/ActivityFeed/ActivityFeed.css
+++ b/web-portal/src/components/ActivityFeed/ActivityFeed.css
@@ -45,6 +45,16 @@
   padding: 0;
 }
 
+.chat-stream:not(.chat-stream--empty) {
+  overflow: hidden;
+}
+
+.activity-feed__virtual {
+  flex: 1;
+  min-height: 0;
+  max-height: 55vh;
+}
+
 @media (max-width: 768px) {
   .activity-feed {
     gap: var(--space-4);

--- a/web-portal/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/web-portal/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,4 +1,5 @@
 import { FeedItem as FeedItemType } from '@/contracts';
+import { VirtualList } from '@/components/ui/VirtualList';
 import { FeedItemRow } from './FeedItem';
 import './ActivityFeed.css';
 
@@ -45,7 +46,14 @@ export function ActivityFeed({ items, channelId, onCollapseAll, onExpandRecent }
             </p>
           </div>
         ) : (
-          items.map((item) => <FeedItemRow key={item.id} item={item} channelId={channelId} />)
+          <VirtualList
+            items={items}
+            getKey={(item) => item.id}
+            testId="channel-messages-virtual"
+            ariaLabel="Channel messages"
+            className="activity-feed__virtual"
+            renderItem={(item) => <FeedItemRow item={item} channelId={channelId} />}
+          />
         )}
       </div>
     </section>

--- a/web-portal/src/components/ActivityFeed/FeedItem.tsx
+++ b/web-portal/src/components/ActivityFeed/FeedItem.tsx
@@ -61,7 +61,12 @@ export function FeedItemRow({ item, channelId }: Props) {
           ) : (
             <div className="feed-item__content">
               {item.kind === 'human_message' || item.kind === 'agent_update' || item.kind === 'court_decision' ? (
-                <MarkdownContent content={item.content} />
+                <MarkdownContent
+                  content={item.content}
+                  context={item.kind === 'court_decision' ? 'proposal' : 'chat'}
+                />
+              ) : item.kind === 'tool_call' ? (
+                <MarkdownContent content={item.content} context="trace" />
               ) : (
                 item.content
               )}

--- a/web-portal/src/components/ui/MarkdownContent.tsx
+++ b/web-portal/src/components/ui/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { sanitizeText, type SanitizeContext } from '@/lib/sanitize';
 import './MarkdownContent.css';
 
 marked.setOptions({ breaks: true, gfm: true });
@@ -8,15 +9,19 @@ marked.setOptions({ breaks: true, gfm: true });
 type Props = {
   content: string;
   className?: string;
+  /** Context-aware redaction before Markdown parse (default: chat). */
+  context?: SanitizeContext;
 };
 
-export function MarkdownContent({ content, className }: Props) {
+export function MarkdownContent({ content, className, context = 'chat' }: Props) {
   const html = useMemo(() => {
-    const raw = marked.parse(content || '', { async: false }) as string;
+    const safe = sanitizeText(context, content || '');
+    const raw = marked.parse(safe, { async: false }) as string;
     return DOMPurify.sanitize(raw, {
       USE_PROFILES: { html: true },
+      ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|#|\/)/i,
     });
-  }, [content]);
+  }, [content, context]);
 
   return (
     <div

--- a/web-portal/src/components/ui/VirtualList.css
+++ b/web-portal/src/components/ui/VirtualList.css
@@ -1,0 +1,24 @@
+.virtual-list {
+  position: relative;
+  overflow-y: auto;
+  max-height: min(70vh, 720px);
+}
+
+.virtual-list__spacer {
+  position: relative;
+  width: 100%;
+}
+
+.virtual-list__window {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
+.virtual-list__meta {
+  display: block;
+  padding: 0.35rem 0.5rem 0;
+  font-size: 0.75rem;
+  text-align: right;
+}

--- a/web-portal/src/components/ui/VirtualList.test.tsx
+++ b/web-portal/src/components/ui/VirtualList.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VirtualList } from './VirtualList';
+
+describe('VirtualList', () => {
+  it('renders all items below threshold without virtualization', () => {
+    const items = Array.from({ length: 5 }, (_, i) => ({ id: `item-${i}` }));
+    render(
+      <VirtualList
+        items={items}
+        getKey={(item) => item.id}
+        testId="test-list"
+        renderItem={(item) => <div data-testid={item.id}>{item.id}</div>}
+      />,
+    );
+    expect(screen.getByTestId('item-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('test-list')).not.toHaveAttribute('data-virtualized');
+  });
+
+  it('virtualizes long lists', () => {
+    const items = Array.from({ length: 150 }, (_, i) => ({ id: `row-${i}` }));
+    render(
+      <VirtualList
+        items={items}
+        getKey={(item) => item.id}
+        testId="long-list"
+        renderItem={(item) => <div>{item.id}</div>}
+      />,
+    );
+    expect(screen.getByTestId('long-list')).toHaveAttribute('data-virtualized', 'true');
+    expect(screen.getByTestId('long-list-virtual-meta')).toHaveTextContent('of 150');
+  });
+});

--- a/web-portal/src/components/ui/VirtualList.tsx
+++ b/web-portal/src/components/ui/VirtualList.tsx
@@ -1,0 +1,89 @@
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import './VirtualList.css';
+
+/** Per performance-targets.md: virtualize once visible list exceeds ~100 items. */
+export const VIRTUAL_LIST_THRESHOLD = 100;
+const DEFAULT_ITEM_HEIGHT = 96;
+const OVERSCAN = 6;
+
+type Props<T> = {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  getKey: (item: T, index: number) => string;
+  estimateItemHeight?: number;
+  threshold?: number;
+  className?: string;
+  testId?: string;
+  ariaLabel?: string;
+};
+
+export function VirtualList<T>({
+  items,
+  renderItem,
+  getKey,
+  estimateItemHeight = DEFAULT_ITEM_HEIGHT,
+  threshold = VIRTUAL_LIST_THRESHOLD,
+  className,
+  testId,
+  ariaLabel,
+}: Props<T>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [range, setRange] = useState({ start: 0, end: Math.min(items.length, 30) });
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const updateRange = useCallback(() => {
+    const el = containerRef.current;
+    if (!el || items.length <= threshold) return;
+    const top = el.scrollTop;
+    const viewH = el.clientHeight || 400;
+    const start = Math.max(0, Math.floor(top / estimateItemHeight) - OVERSCAN);
+    const visible = Math.ceil(viewH / estimateItemHeight) + OVERSCAN * 2;
+    const end = Math.min(items.length, start + visible);
+    setScrollTop(top);
+    setRange((prev) => (prev.start === start && prev.end === end ? prev : { start, end }));
+  }, [estimateItemHeight, items.length, threshold]);
+
+  useEffect(() => {
+    updateRange();
+  }, [items.length, updateRange]);
+
+  if (items.length <= threshold) {
+    return (
+      <div className={className} data-testid={testId} aria-label={ariaLabel}>
+        {items.map((item, i) => (
+          <div key={getKey(item, i)}>{renderItem(item, i)}</div>
+        ))}
+      </div>
+    );
+  }
+
+  const totalHeight = items.length * estimateItemHeight;
+  const slice = items.slice(range.start, range.end);
+  const offsetY = range.start * estimateItemHeight;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`virtual-list${className ? ` ${className}` : ''}`}
+      data-testid={testId}
+      data-virtualized="true"
+      aria-label={ariaLabel}
+      onScroll={updateRange}
+      role="log"
+      tabIndex={0}
+    >
+      <div className="virtual-list__spacer" style={{ height: totalHeight }}>
+        <div className="virtual-list__window" style={{ transform: `translateY(${offsetY}px)` }}>
+          {slice.map((item, i) => {
+            const index = range.start + i;
+            return <div key={getKey(item, index)}>{renderItem(item, index)}</div>;
+          })}
+        </div>
+      </div>
+      <span className="virtual-list__meta subtle" data-testid={`${testId}-virtual-meta`} aria-hidden="true">
+        Showing {range.start + 1}–{range.end} of {items.length}
+        {scrollTop > 0 ? '' : ''}
+      </span>
+    </div>
+  );
+}

--- a/web-portal/src/lib/sanitize.test.ts
+++ b/web-portal/src/lib/sanitize.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { PROPOSAL_NOTE_MAX_LEN, sanitizeProposalNote } from './sanitize';
+import {
+  PROPOSAL_NOTE_MAX_LEN,
+  sanitizeLinkHref,
+  sanitizeProposalNote,
+  sanitizeText,
+} from './sanitize';
 
 describe('sanitizeProposalNote', () => {
   it('returns undefined for empty input', () => {
@@ -20,5 +25,38 @@ describe('sanitizeProposalNote', () => {
   it('caps length', () => {
     const long = 'x'.repeat(PROPOSAL_NOTE_MAX_LEN + 50);
     expect(sanitizeProposalNote(long)?.length).toBe(PROPOSAL_NOTE_MAX_LEN);
+  });
+});
+
+describe('sanitizeText', () => {
+  it('redacts secrets and internal paths in trace context', () => {
+    const out = sanitizeText('trace', 'api_key: sk-live-abc read /etc/passwd host 10.0.0.5');
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('/etc/passwd');
+    expect(out).not.toContain('10.0.0.5');
+  });
+
+  it('escapes script tags in chat context', () => {
+    const out = sanitizeText('chat', '<script>alert(1)</script> hi');
+    expect(out).not.toContain('<script');
+    expect(out).toContain('&lt;script');
+  });
+
+  it('truncates very long trace content', () => {
+    const out = sanitizeText('trace', 'x'.repeat(9000));
+    expect(out.length).toBeLessThan(8100);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});
+
+describe('sanitizeLinkHref', () => {
+  it('allows safe protocols', () => {
+    expect(sanitizeLinkHref('https://example.com')).toBe('https://example.com');
+    expect(sanitizeLinkHref('#section')).toBe('#section');
+  });
+
+  it('blocks javascript URLs', () => {
+    expect(sanitizeLinkHref('javascript:alert(1)')).toBeNull();
+    expect(sanitizeLinkHref('data:text/html,evil')).toBeNull();
   });
 });

--- a/web-portal/src/lib/sanitize.ts
+++ b/web-portal/src/lib/sanitize.ts
@@ -1,9 +1,21 @@
 /** Max length for optional proposal action notes sent to the bridge. */
 export const PROPOSAL_NOTE_MAX_LEN = 2000;
 
+/** Context-aware sanitization per security-boundaries.md */
+export type SanitizeContext = 'chat' | 'trace' | 'proposal';
+
 const HTML_TAG = /<[^>]*>/g;
 const SCRIPT_BLOCK = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
 const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const API_KEY = /(api[_-]?key|secret|password|token|bearer)\s*[:=]\s*\S+/gi;
+const CREDENTIAL = /(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,})/gi;
+const INTERNAL_PATH = /\/(etc|var|opt|proc|sys|home|root)\/[^\s]*/g;
+const PRIVATE_IP =
+  /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const INTERNAL_HOST = /\b[a-zA-Z0-9-]+\.(internal|local|svc|cluster)\b/g;
+
+const REDACTED = '[REDACTED]';
+const TRACE_MAX_LEN = 8000;
 
 /**
  * Sanitize user-supplied proposal action notes before JSON POST.
@@ -17,4 +29,47 @@ export function sanitizeProposalNote(raw: string | undefined | null): string | u
     s = s.slice(0, PROPOSAL_NOTE_MAX_LEN);
   }
   return s;
+}
+
+/** Context-aware plain-text redaction before Markdown rendering. */
+export function sanitizeText(ctx: SanitizeContext, raw: string): string {
+  if (!raw) return '';
+  let s = raw;
+  s = s.replace(API_KEY, (match, label: string) => `${label || match.split(/[:=]/)[0].trim()}: ${REDACTED}`);
+  s = s.replace(CREDENTIAL, REDACTED);
+  s = s.replace(INTERNAL_PATH, REDACTED);
+  s = s.replace(PRIVATE_IP, REDACTED);
+  s = s.replace(INTERNAL_HOST, REDACTED);
+
+  switch (ctx) {
+    case 'chat':
+      s = s.replace(/<script/gi, '&lt;script').replace(/<\/script/gi, '&lt;/script');
+      s = s.replace(/<iframe/gi, '&lt;iframe');
+      break;
+    case 'trace':
+      if (s.length > TRACE_MAX_LEN) {
+        s = s.slice(0, TRACE_MAX_LEN) + '…';
+      }
+      break;
+    case 'proposal':
+      break;
+  }
+  return s;
+}
+
+/** Allowed link protocols for rendered Markdown. */
+export function sanitizeLinkHref(href: string): string | null {
+  const trimmed = (href || '').trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('javascript:') || lower.startsWith('data:') || lower.startsWith('vbscript:')) {
+    return null;
+  }
+  if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('mailto:')) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('#') || trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  return null;
 }

--- a/web-portal/src/views/TraceView.tsx
+++ b/web-portal/src/views/TraceView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { api } from '@/api/client';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { MarkdownContent } from '@/components/ui/MarkdownContent';
+import { VirtualList } from '@/components/ui/VirtualList';
 import { AgentTrace } from '@/contracts';
 import { agentActionConfirmCopy, type AgentControlAction } from '@/lib/confirmCopy';
 import { usePortalStore } from '@/store/portalStore';
@@ -89,13 +91,21 @@ export function TraceView() {
             No trace phases yet.
           </p>
         ) : (
-          trace.phases.map((phase, i) => (
-            <article key={i} className="list-card">
-              <strong>{phase.phase}</strong>
-              <p>{phase.summary}</p>
-              {phase.tool && <code>{phase.tool}</code>}
-            </article>
-          ))
+          <VirtualList
+            items={trace.phases}
+            getKey={(phase, i) => `${phase.phase}-${phase.ts || i}`}
+            testId="trace-timeline-virtual"
+            estimateItemHeight={120}
+            renderItem={(phase) => (
+              <article className="list-card">
+                <strong>{phase.phase}</strong>
+                <div className="trace-phase-summary">
+                  <MarkdownContent content={phase.summary || ''} context="trace" />
+                </div>
+                {phase.tool && <code>{phase.tool}</code>}
+              </article>
+            )}
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary

Addresses all four deferred items tracked in #73 from the PR #72 web portal delivery.

## Changes

### 1. PM-structured STOMP harness events
- `publishHarnessDeltas()` diffs harness state on channel activity and emits `harness.*` events to `/topic/harness.{planId}.updates`
- Maintains backward-compatible `channel.activity` wrapper

### 2. Rate limiting
- Per-IP token buckets for proposal actions, agent controls, member removal, channel archive
- HTTP 429 + `Retry-After: 60`

### 3. Context-aware Markdown sanitizer (client)
- `sanitizeText()` mirrors server redaction rules
- Wired through `MarkdownContent` / `FeedItem` with chat/trace/proposal contexts

### 4. Virtual scrolling
- `VirtualList` component (100-item threshold) for activity feeds and trace timelines

## Tests
- `go test ./internal/dashboard/...`
- `cd web-portal && npm test && npm run build`

Closes #73