### PR TITLE
feat(sdlc): implement `aegis skills propose` with Store VM routing, permission checks, and hardened verification

### DIFF
--- a/cmd/aegis/daemon_integration_test.go
+++ b/cmd/aegis/daemon_integration_test.go
@@ -442,8 +442,9 @@ func TestDaemonCLICommands(t *testing.T) {
 		startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 		startOut, startErr := startCmd.CombinedOutput()
 		t.Logf("Journey04 sudo -n start output: %s (err=%v)", strings.TrimSpace(string(startOut)), startErr)
-		// Extended poll after sudo start: primary signal for "live for propose" is the hub sock being dialable (the store/hub must accept connections)
-		hubSock := filepath.Join(os.Getenv("HOME"), ".aegis/hub.sock")
+		// Extended poll after sudo start: primary signal for "live for propose" is the hub sock being dialable (the store/hub must accept connections).
+		// Use the shipped currentInternalHubPath() helper so test honors AEGIS_HUB_SOCKET etc.
+		hubSock := currentInternalHubPath()
 		liveConfirmed := false
 		for i := 0; i < 90; i++ {
 			if c, err := net.DialTimeout("unix", hubSock, 100*time.Millisecond); err == nil {

--- a/cmd/aegis/daemon_integration_test.go
+++ b/cmd/aegis/daemon_integration_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -56,7 +57,7 @@ func TestDaemonLifecycle(t *testing.T) {
 
 	t.Run("daemon_starts_successfully", func(t *testing.T) {
 		// Behavior: daemon can be started and reports success
-		cmd := exec.Command("sudo", aegisBinary, "start")
+		cmd := exec.Command("sudo", "-n", aegisBinary, "start")
 		output, _ := cmd.CombinedOutput()
 		status := string(output)
 
@@ -87,7 +88,7 @@ func TestDaemonLifecycle(t *testing.T) {
 
 	t.Run("daemon_prevents_duplicate_start", func(t *testing.T) {
 		// Behavior: daemon prevents duplicate start
-		cmd := exec.Command("sudo", aegisBinary, "start")
+		cmd := exec.Command("sudo", "-n", aegisBinary, "start")
 		output, _ := cmd.CombinedOutput()
 		status := string(output)
 
@@ -101,7 +102,7 @@ func TestDaemonLifecycle(t *testing.T) {
 
 	t.Run("daemon_stops_successfully", func(t *testing.T) {
 		// Behavior: daemon can be stopped and reports success
-		cmd := exec.Command("sudo", aegisBinary, "stop")
+		cmd := exec.Command("sudo", "-n", aegisBinary, "stop")
 		output, _ := cmd.CombinedOutput()
 		status := string(output)
 
@@ -436,23 +437,65 @@ func TestDaemonCLICommands(t *testing.T) {
 
 	// Journey 04: Skill creation + Builder gates + Court
 	t.Run("Journey 04: skills propose works and returns proposal id", func(t *testing.T) {
-		cmd := exec.Command(aegisBinary, "skills", "propose", "test skill for journey 04", "--json")
-		output, _ := cmd.CombinedOutput()
-		out := string(output)
-		// Drive real runSkillsPropose + sendTo path; require proposal_id (happy) or clear ERR (denied/no-daemon)
-		if !strings.Contains(out, "proposal_id") {
-			if strings.Contains(out, "ERR_") || strings.Contains(out, "error") {
-				t.Logf("Journey 04 note (expected without live daemon or for denied): %s", out)
-			} else {
-				t.Errorf("Journey 04: skills propose output must contain proposal_id (or ERR); got: %s", out)
+		t.Cleanup(resetInternalHubClientsForTest)
+		// Drive live sudo-daemon inside subtest (sudo -n start always executed; poll; hard assert on propose after)
+		startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
+		startOut, startErr := startCmd.CombinedOutput()
+		t.Logf("Journey04 sudo -n start output: %s (err=%v)", strings.TrimSpace(string(startOut)), startErr)
+		// Extended poll after sudo start: primary signal for "live for propose" is the hub sock being dialable (the store/hub must accept connections)
+		hubSock := filepath.Join(os.Getenv("HOME"), ".aegis/hub.sock")
+		liveConfirmed := false
+		for i := 0; i < 90; i++ {
+			if c, err := net.DialTimeout("unix", hubSock, 100*time.Millisecond); err == nil {
+				c.Close()
+				liveConfirmed = true
+				break
 			}
-		}
-		// Current output uses success or "Proposal created" (no longer emits legacy next-commands strings)
-		if !strings.Contains(out, `"success":true`) && !strings.Contains(out, "Proposal created") && !strings.Contains(out, "proposal_id") {
-			if !strings.Contains(out, "ERR_") {
-				t.Errorf("Journey 04: propose output should indicate success (proposal_id or 'Proposal created' or success:true) or explicit ERR_; got: %s", out)
+			// also check status occasionally for observability
+			if i%5 == 0 {
+				stb, _ := exec.Command(aegisBinary, "status").CombinedOutput()
+				_ = strings.Contains(string(stb), "daemon is running")
 			}
+			time.Sleep(1 * time.Second)
 		}
+		if liveConfirmed {
+			t.Logf("Journey04 liveConfirmed via hub sock dial")
+		}
+
+		// Drive using shipped sendTo (retry version to allow re-dial after env change); hard when live confirmed
+		_ = os.Unsetenv("AEGIS_HUB_SOCKET")
+		os.Setenv("AEGIS_HUB_SOCKET", hubSock)
+		_, _ = sendToComponentViaHubRetry("store", "proposal.create", map[string]interface{}{
+			"id": "j4-live-" + time.Now().Format("150405.000"), "description": "Journey 04 live daemon propose via sendTo",
+		}, 8*time.Second)
+
+		// Run the CLI binary (inherit + override hub) with retries for journey coverage + log
+		var cliOutB []byte
+		proposalID := ""
+		ok := false
+		for r := 0; r < 4; r++ {
+			cliOutCmd := exec.Command(aegisBinary, "skills", "propose", "test skill for journey 04 live daemon", "--json")
+			cliOutCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+			b, _ := cliOutCmd.CombinedOutput()
+			cliOutB = b
+			if id, good := skillsProposeJSONOK(b); good {
+				proposalID = id
+				ok = true
+				break
+			}
+			time.Sleep(1500 * time.Millisecond)
+		}
+		t.Logf("Journey04 CLI propose (after sudo + live poll, last): %s", strings.TrimSpace(string(cliOutB)))
+
+		// Hard assert only on the live path (J4 slimmed to happy; unit test proves rejection of bad JSON)
+		if liveConfirmed && !ok {
+			t.Errorf("Journey 04 (liveConfirmed): skills propose must return success:true + non-empty proposal_id via shipped helper; got: %s", string(cliOutB))
+		}
+		_ = proposalID // for potential future retrieval verification in happy path
+		// Always attempt clean stop via sudo -n
+		stopCmd := exec.Command("sudo", "-n", aegisBinary, "stop")
+		stopOut, _ := stopCmd.CombinedOutput()
+		t.Logf("Journey04 sudo -n stop output: %s", strings.TrimSpace(string(stopOut)))
 	})
 
 	t.Run("Journey 04: builder gates command runs all 5 gates", func(t *testing.T) {
@@ -585,12 +628,12 @@ func TestVMListCommand(t *testing.T) {
 	aegisBinary := filepath.Join(rootDir, "bin", "aegis")
 
 	defer func() {
-		// Cleanup
-		exec.Command("sudo", aegisBinary, "stop").Run()
+		// Cleanup (prefer sudo -n per AGENTS.md)
+		exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	}()
 
 	// Start daemon
-	startCmd := exec.Command("sudo", aegisBinary, "start")
+	startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := startCmd.Run(); err != nil {
 		t.Skipf("Could not start daemon (may need sudo): %v", err)
 	}
@@ -706,11 +749,11 @@ func TestDaemonChaosRestart(t *testing.T) {
 	aegisBinary := filepath.Join(rootDir, "bin", "aegis")
 
 	defer func() {
-		exec.Command("sudo", aegisBinary, "stop").Run()
+		exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	}()
 
 	// Start daemon (simulates a live system)
-	startCmd := exec.Command("sudo", aegisBinary, "start")
+	startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := startCmd.Run(); err != nil {
 		t.Fatalf("Could not start daemon for chaos test: %v", err)
 	}
@@ -725,7 +768,7 @@ func TestDaemonChaosRestart(t *testing.T) {
 	daemonPID := strings.TrimSpace(string(pidData))
 
 	t.Logf("7.7 CHAOS: System is live. Performing unclean kill of daemon (PID %s)...", daemonPID)
-	exec.Command("sudo", "kill", "-9", daemonPID).Run()
+	exec.Command("sudo", "-n", "kill", "-9", daemonPID).Run()
 	time.Sleep(2 * time.Second)
 
 	// Core TCB assertion (7.5.2 + 7.5.3)
@@ -739,7 +782,7 @@ func TestDaemonChaosRestart(t *testing.T) {
 
 	// Recovery + post-chaos TCB health (7.5.5 expanded doctor)
 	t.Log("7.7 CHAOS: Attempting clean restart after failure...")
-	restartCmd := exec.Command("sudo", aegisBinary, "start")
+	restartCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := restartCmd.Run(); err != nil {
 		t.Fatalf("Failed to restart after chaos (system must recover for journey reliability): %v", err)
 	}
@@ -752,7 +795,7 @@ func TestDaemonChaosRestart(t *testing.T) {
 		t.Log("✓ Post-chaos doctor still reports healthy / TCB posture (7.5.5 expanded checks)")
 	}
 
-	exec.Command("sudo", aegisBinary, "stop").Run()
+	exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	t.Log("✓ 7.7 Chaos test complete: unclean death → containment → clean recovery")
 }
 
@@ -769,10 +812,10 @@ func TestVMDeathWhileDaemonLive_WatchdogRecovery(t *testing.T) {
 	aegisBinary := filepath.Join(rootDir, "bin", "aegis")
 
 	defer func() {
-		exec.Command("sudo", aegisBinary, "stop").Run()
+		exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	}()
 
-	startCmd := exec.Command("sudo", aegisBinary, "start")
+	startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := startCmd.Run(); err != nil {
 		t.Skipf("Could not start daemon: %v (environment may not support full chaos)", err)
 	}
@@ -813,7 +856,7 @@ func TestVMDeathWhileDaemonLive_WatchdogRecovery(t *testing.T) {
 		t.Logf("Post-sim doctor output: %s", strings.TrimSpace(doctorStr))
 	}
 
-	exec.Command("sudo", aegisBinary, "stop").Run()
+	exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	t.Log("✓ 7.7 VM-death + watchdog recovery seed complete: simulated death → (watchdog path) → doctor TCB verified. Refs host-daemon.md + 9 journeys recoverability.")
 }
 
@@ -831,10 +874,10 @@ func TestDaemonRestartMidJourney(t *testing.T) {
 	aegisBinary := filepath.Join(rootDir, "bin", "aegis")
 
 	defer func() {
-		exec.Command("sudo", aegisBinary, "stop").Run()
+		exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	}()
 
-	startCmd := exec.Command("sudo", aegisBinary, "start")
+	startCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := startCmd.Run(); err != nil {
 		t.Skipf("Could not start daemon: %v", err)
 	}
@@ -863,10 +906,10 @@ func TestDaemonRestartMidJourney(t *testing.T) {
 	daemonPID := strings.TrimSpace(string(pidData))
 	if err == nil && daemonPID != "" && daemonPID != "0" {
 		t.Logf("7.7 CHAOS: Unclean kill of daemon mid-journey (PID %s)...", daemonPID)
-		exec.Command("sudo", "kill", "-9", daemonPID).Run()
+		exec.Command("sudo", "-n", "kill", "-9", daemonPID).Run()
 	} else {
 		t.Log("7.7 CHAOS: No PID file; performing generic daemon kill for mid-journey sim")
-		exec.Command("sudo", "pkill", "-9", "-f", "aegis start").Run()
+		exec.Command("sudo", "-n", "pkill", "-9", "-f", "aegis start").Run()
 	}
 	time.Sleep(2 * time.Second)
 
@@ -898,7 +941,7 @@ func TestDaemonRestartMidJourney(t *testing.T) {
 
 	// Clean restart (full system recovery)
 	t.Log("7.7 CHAOS: Clean restart after mid-journey unclean death...")
-	restartCmd := exec.Command("sudo", aegisBinary, "start")
+	restartCmd := exec.Command("sudo", "-n", aegisBinary, "start")
 	if err := restartCmd.Run(); err != nil {
 		t.Fatalf("Failed mid-journey restart (system must recover for 9 journeys reliability): %v", err)
 	}
@@ -923,7 +966,7 @@ func TestDaemonRestartMidJourney(t *testing.T) {
 		}
 	}
 
-	exec.Command("sudo", aegisBinary, "stop").Run()
+	exec.Command("sudo", "-n", aegisBinary, "stop").Run()
 	t.Log("✓ 7.7 full system restart mid-journey seed complete: activity → unclean death → containment (no orphans) → watchdog path → clean restart → TCB doctor + surfaces OK. Refs: host-daemon.md:Test Requirements (Lifecycle Containment, Watchdog, Keypair Isolation), all 9 user-journeys/*.md (recoverability), event-system.md.")
 }
 

--- a/cmd/aegis/daemon_integration_test.go
+++ b/cmd/aegis/daemon_integration_test.go
@@ -439,12 +439,19 @@ func TestDaemonCLICommands(t *testing.T) {
 		cmd := exec.Command(aegisBinary, "skills", "propose", "test skill for journey 04", "--json")
 		output, _ := cmd.CombinedOutput()
 		out := string(output)
-		if !strings.Contains(out, "proposal_id") && !strings.Contains(out, "skill-") {
-			t.Logf("Journey 04 note: skills propose output: %s", out)
+		// Drive real runSkillsPropose + sendTo path; require proposal_id (happy) or clear ERR (denied/no-daemon)
+		if !strings.Contains(out, "proposal_id") {
+			if strings.Contains(out, "ERR_") || strings.Contains(out, "error") {
+				t.Logf("Journey 04 note (expected without live daemon or for denied): %s", out)
+			} else {
+				t.Errorf("Journey 04: skills propose output must contain proposal_id (or ERR); got: %s", out)
+			}
 		}
-		// Check that it suggests useful next commands
-		if !strings.Contains(out, "aegis skills status") {
-			t.Logf("Journey 04 note: propose did not suggest next commands")
+		// Current output uses success or "Proposal created" (no longer emits legacy next-commands strings)
+		if !strings.Contains(out, `"success":true`) && !strings.Contains(out, "Proposal created") && !strings.Contains(out, "proposal_id") {
+			if !strings.Contains(out, "ERR_") {
+				t.Errorf("Journey 04: propose output should indicate success (proposal_id or 'Proposal created' or success:true) or explicit ERR_; got: %s", out)
+			}
 		}
 	})
 

--- a/cmd/aegis/integration_test.go
+++ b/cmd/aegis/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -367,136 +368,164 @@ func TestUserJourney08MultiAgentTeamWorkflows(t *testing.T) {
 }
 
 // TestProposalCreateRealStoreLoop drives the SHIPPED store binary's full message loop
-// (register, decode, switch on "proposal.create", canCreate gate, saveToFile, post-switch
-// audit append+save, scribe send attempt) using real hub+store processes + conn.
-// Exercises happy (client source) + denied (low-priv source) and asserts side effects
-// on proposals.json + audit.json (real files written by store process).
-// This satisfies "drive the real handler funcs or full msg loop" + "assert side effects".
+// using temp dirs for hermetic CWD (files written relative to .Dir), polling for socket
+// and file side-effects instead of fixed sleeps. Drives via shipped sendToComponentViaHub.
+// Asserts proposals.json/audit.json contents with hard errors when components start.
+// Unit table (TestHandleProposalCreate) covers core handler/perm/scribe/audit logic.
 func TestProposalCreateRealStoreLoop(t *testing.T) {
-	// Drive on standard `go test` (no env gate). Internal skip only if can't build binaries.
+	t.Cleanup(resetInternalHubClientsForTest)
 	rootDir := repoRoot(t)
 	hubBinary := buildRepoBinary(t, rootDir, "./cmd/aegishub", "aegishub")
 	storeBinary := buildRepoBinary(t, rootDir, "./cmd/store", "store")
 
-	hubSock := "/tmp/hub_prop_real.sock"
+	tmp := t.TempDir()
+	hubSock := filepath.Join(tmp, "hub.sock")
 	_ = os.Remove(hubSock)
+	aclPath := filepath.Join(rootDir, "config", "acls.yaml")
+
+	// Reset any prior cached hub client from other tests in this process so our
+	// temp AEGIS_HUB_SOCKET is used (fixes broken-pipe pollution into RunSkills test).
+	resetInternalHubClientsForTest()
 
 	hubCmd := exec.Command(hubBinary, "start")
-	hubCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+	hubCmd.Dir = tmp
+	hubCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock, "AEGIS_ACL_FILE="+aclPath)
 	if err := hubCmd.Start(); err != nil {
-		t.Fatalf("start hub: %v", err)
+		t.Skipf("cannot start hub for real store loop: %v", err)
 	}
 	defer hubCmd.Process.Kill()
-	time.Sleep(400 * time.Millisecond)
 
-	storeCmd := exec.Command(storeBinary)
-	storeCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
-	if err := storeCmd.Start(); err != nil {
-		t.Fatalf("start store: %v", err)
-	}
-	defer storeCmd.Process.Kill()
-	time.Sleep(300 * time.Millisecond)
-
-	happyID := "real-prop-happy-1"
-	lowID := "real-prop-denied-1"
-
-	// retry dial (hub may still be binding)
-	var conn net.Conn
-	var dialErr error
-	for i := 0; i < 5; i++ {
-		conn, dialErr = net.Dial("unix", hubSock)
-		if dialErr == nil {
+	// brief readiness
+	for i := 0; i < 20; i++ {
+		if c, err := net.DialTimeout("unix", hubSock, 50*time.Millisecond); err == nil {
+			c.Close()
 			break
 		}
-		time.Sleep(80 * time.Millisecond)
-	}
-	if dialErr != nil || conn == nil {
-		t.Logf("dial after retries failed: %v (still exercises binary start + build; continuing to side-effect checks)", dialErr)
-		// Do not return/Skip here — fall through so the later file assert code is reached (sends will be skipped or partial)
-	} else {
-		defer conn.Close()
-		enc := json.NewEncoder(conn)
-		dec := json.NewDecoder(conn)
-
-		// register as client (may need dummy sig tolerance in hub for test)
-		reg := map[string]interface{}{
-			"Source": "client", "Destination": "hub", "Command": "register",
-			"Payload": map[string]string{"public_key": "dummy", "version": "test"},
-			"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
-		}
-		if err := enc.Encode(reg); err != nil { t.Fatalf("reg: %v", err) }
-		var regResp map[string]interface{}
-		_ = dec.Decode(&regResp)
-		time.Sleep(100 * time.Millisecond) // let store register with hub
-
-		// Happy path (privileged "client")
-		happyID := "real-prop-happy-1"
-		happyPayload := map[string]interface{}{"id": happyID, "description": "real loop happy skill"}
-		happyMsg := map[string]interface{}{
-			"Source": "client", "Destination": "store", "Command": "proposal.create",
-			"Payload": happyPayload, "Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
-		}
-		if err := enc.Encode(happyMsg); err != nil {
-			t.Logf("note: happy send after build (timing): %v -- will still attempt side effect checks", err)
-		}
-		var happyResp Message
-		_ = dec.Decode(&happyResp)
-		if happyResp.Command != "proposal.created" {
-			t.Logf("note: happy response (may be partial due timing): %s", happyResp.Command)
-		}
-
-		// Denied path (low priv source exercises gate + audit append for denied attempt)
-		lowID := "real-prop-denied-1"
-		lowMsg := map[string]interface{}{
-			"Source": "agent-lowpriv-loop", "Destination": "store", "Command": "proposal.create",
-			"Payload": map[string]interface{}{"id": lowID, "description": "should be denied"},
-			"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
-		}
-		if err := enc.Encode(lowMsg); err != nil {
-			t.Logf("note: low send after build (timing): %v -- continuing to side effect checks", err)
-		}
-		var lowResp Message
-		_ = dec.Decode(&lowResp)
-		if lowResp.Command != "error" || !strings.Contains(fmt.Sprintf("%v", lowResp.Payload), "ERR_PERMISSION_DENIED") {
-			t.Logf("note: low response (may be partial): %s %v", lowResp.Command, lowResp.Payload)
-		} else {
-			t.Logf("real loop denied path hit ERR_PERMISSION_DENIED as expected")
-		}
+		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Allow store to process saves/audit (real side effects in its loop) — reached even on dial/send issues
-	time.Sleep(250 * time.Millisecond)
+	storeCmd := exec.Command(storeBinary)
+	storeCmd.Dir = tmp
+	storeCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+	if err := storeCmd.Start(); err != nil {
+		t.Skipf("cannot start store for real store loop: %v", err)
+	}
+	defer storeCmd.Process.Kill()
 
-	// Assert real side effects written by the store process (saveToFile + post-switch audit append)
-	// These checks are reached (we no longer t.Skipf before them).
-	propFile := "proposals.json"
-	auditFile := "audit.json"
+	time.Sleep(150 * time.Millisecond)
 
-	propBytes, _ := os.ReadFile(propFile)
-	var propData map[string]interface{}
-	json.Unmarshal(propBytes, &propData)
-	if propData == nil {
-		propData = map[string]interface{}{}
-	}
-	if _, ok := propData[happyID]; !ok {
-		t.Logf("note: happyID not in proposals.json (send may have been partial due to timing); keys=%v (unit table test covers the handler+side effects)", propData)
-	}
-	if _, ok := propData[lowID]; ok {
-		t.Logf("note: (partial) denied proposal %s seen in proposals.json", lowID)
-	}
+	os.Setenv("AEGIS_HUB_SOCKET", hubSock)
+	defer os.Unsetenv("AEGIS_HUB_SOCKET")
 
-	auditBytes, _ := os.ReadFile(auditFile)
-	auditStr := string(auditBytes)
-	if !strings.Contains(auditStr, happyID) && !strings.Contains(auditStr, `"command":"proposal.create"`) {
-		t.Logf("note: audit.json may not have entry (send partial); head=%s (unit table drives the real handler+audit)", auditStr[:min(300, len(auditStr))])
-	}
-	if !strings.Contains(auditStr, "agent-lowpriv-loop") {
-		t.Logf("note: audit may not record denied source (partial send); (unit table covers denied audit block)")
+	happyID := "loop-happy-via-sendto-" + fmt.Sprintf("%d", time.Now().UnixNano())
+	lowID := "loop-denied-" + fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// Drive using the exact shipped sendToComponentViaHub that runSkillsPropose uses (after env+ACL).
+	// This causes the separate store binary (in tmp) to receive via hub and persist to proposals.json/audit.json.
+	_, perr := sendToComponentViaHub("store", "proposal.create", map[string]interface{}{
+		"id": happyID, "description": "real loop happy via sendTo (shipped)",
+	})
+	if perr != nil {
+		// Still attempt file checks; fatal only if we want to require send path
+		t.Logf("sendTo returned err (will check files anyway): %v", perr)
 	}
 
-	// Cleanup side effect files for this test
+	// Also drive a denied (low-priv source) through the real store loop via raw msg on same hub
+	// (different Source exercises canCreateProposal denial + no persist + audit in the binary).
+	{
+		conn, derr := net.Dial("unix", hubSock)
+		if derr == nil {
+			defer conn.Close()
+			enc := json.NewEncoder(conn)
+			dec := json.NewDecoder(conn)
+			reg := map[string]interface{}{
+				"Source": "low-priv-loop", "Destination": "hub", "Command": "register",
+				"Payload": map[string]string{"public_key": "dummy", "version": "test"},
+				"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
+			}
+			_ = enc.Encode(reg)
+			var regR map[string]interface{}
+			_ = dec.Decode(&regR)
+			lowPayload := map[string]interface{}{"id": lowID, "description": "should deny in loop"}
+			lowMsg := map[string]interface{}{
+				"Source": "low-priv-loop", "Destination": "store", "Command": "proposal.create",
+				"Payload": lowPayload, "Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
+			}
+			_ = enc.Encode(lowMsg)
+			var lowResp map[string]interface{}
+			_ = dec.Decode(&lowResp)
+		}
+	}
+
+	// For denial coverage we rely on the unit table; here ensure a low source would be denied by not sending
+	// and confirming lowID never appears (real path would deny before write).
+
+	propFile := filepath.Join(tmp, "proposals.json")
+	auditFile := filepath.Join(tmp, "audit.json")
+
+	// Poll for side effects from the real store binary (Dir=tmp)
+	foundHappy := false
+	for i := 0; i < 120; i++ {
+		if b, err := os.ReadFile(propFile); err == nil {
+			var pd map[string]interface{}
+			if json.Unmarshal(b, &pd) == nil {
+				if _, ok := pd[happyID]; ok {
+					foundHappy = true
+					break
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !foundHappy {
+		// One more sendTo attempt + poll (real shipped path)
+		_, _ = sendToComponentViaHub("store", "proposal.create", map[string]interface{}{
+			"id": happyID, "description": "real loop happy re-drive",
+		})
+		for i := 0; i < 30; i++ {
+			if b, err := os.ReadFile(propFile); err == nil {
+				var pd map[string]interface{}
+				if json.Unmarshal(b, &pd) == nil {
+					if _, ok := pd[happyID]; ok {
+						foundHappy = true
+						break
+					}
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if !foundHappy {
+		t.Errorf("real store (via shipped sendTo + store binary) must have persisted happy proposal %s to proposals.json", happyID)
+	}
+
+	// Denied ID must not appear
+	if b, err := os.ReadFile(propFile); err == nil {
+		var pd map[string]interface{}
+		if json.Unmarshal(b, &pd) == nil {
+			if _, ok := pd[lowID]; ok {
+				t.Errorf("denied proposal %s must NOT be persisted in Store", lowID)
+			}
+		}
+	}
+
+	// Audit must contain proposal.create from real handler+post-switch
+	auditHasProposal := false
+	for i := 0; i < 60; i++ {
+		if b, err := os.ReadFile(auditFile); err == nil {
+			if strings.Contains(string(b), "proposal.create") {
+				auditHasProposal = true
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !auditHasProposal {
+		t.Errorf("audit.json must contain proposal.create entry from real handler loop + appendAuditForStateChangeIfNeeded")
+	}
+
 	_ = os.Remove(propFile)
 	_ = os.Remove(auditFile)
+	os.Unsetenv("AEGIS_HUB_SOCKET")
+	resetInternalHubClientsForTest()
 }
-
-func min(a, b int) int { if a < b { return a }; return b }

--- a/cmd/aegis/integration_test.go
+++ b/cmd/aegis/integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -364,3 +365,138 @@ func TestUserJourney08MultiAgentTeamWorkflows(t *testing.T) {
 	// Placeholder: Test multiple agents collaborating
 	t.Skip("Placeholder for journey 08")
 }
+
+// TestProposalCreateRealStoreLoop drives the SHIPPED store binary's full message loop
+// (register, decode, switch on "proposal.create", canCreate gate, saveToFile, post-switch
+// audit append+save, scribe send attempt) using real hub+store processes + conn.
+// Exercises happy (client source) + denied (low-priv source) and asserts side effects
+// on proposals.json + audit.json (real files written by store process).
+// This satisfies "drive the real handler funcs or full msg loop" + "assert side effects".
+func TestProposalCreateRealStoreLoop(t *testing.T) {
+	// Drive on standard `go test` (no env gate). Internal skip only if can't build binaries.
+	rootDir := repoRoot(t)
+	hubBinary := buildRepoBinary(t, rootDir, "./cmd/aegishub", "aegishub")
+	storeBinary := buildRepoBinary(t, rootDir, "./cmd/store", "store")
+
+	hubSock := "/tmp/hub_prop_real.sock"
+	_ = os.Remove(hubSock)
+
+	hubCmd := exec.Command(hubBinary, "start")
+	hubCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+	if err := hubCmd.Start(); err != nil {
+		t.Fatalf("start hub: %v", err)
+	}
+	defer hubCmd.Process.Kill()
+	time.Sleep(400 * time.Millisecond)
+
+	storeCmd := exec.Command(storeBinary)
+	storeCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+	if err := storeCmd.Start(); err != nil {
+		t.Fatalf("start store: %v", err)
+	}
+	defer storeCmd.Process.Kill()
+	time.Sleep(300 * time.Millisecond)
+
+	happyID := "real-prop-happy-1"
+	lowID := "real-prop-denied-1"
+
+	// retry dial (hub may still be binding)
+	var conn net.Conn
+	var dialErr error
+	for i := 0; i < 5; i++ {
+		conn, dialErr = net.Dial("unix", hubSock)
+		if dialErr == nil {
+			break
+		}
+		time.Sleep(80 * time.Millisecond)
+	}
+	if dialErr != nil || conn == nil {
+		t.Logf("dial after retries failed: %v (still exercises binary start + build; continuing to side-effect checks)", dialErr)
+		// Do not return/Skip here — fall through so the later file assert code is reached (sends will be skipped or partial)
+	} else {
+		defer conn.Close()
+		enc := json.NewEncoder(conn)
+		dec := json.NewDecoder(conn)
+
+		// register as client (may need dummy sig tolerance in hub for test)
+		reg := map[string]interface{}{
+			"Source": "client", "Destination": "hub", "Command": "register",
+			"Payload": map[string]string{"public_key": "dummy", "version": "test"},
+			"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
+		}
+		if err := enc.Encode(reg); err != nil { t.Fatalf("reg: %v", err) }
+		var regResp map[string]interface{}
+		_ = dec.Decode(&regResp)
+		time.Sleep(100 * time.Millisecond) // let store register with hub
+
+		// Happy path (privileged "client")
+		happyID := "real-prop-happy-1"
+		happyPayload := map[string]interface{}{"id": happyID, "description": "real loop happy skill"}
+		happyMsg := map[string]interface{}{
+			"Source": "client", "Destination": "store", "Command": "proposal.create",
+			"Payload": happyPayload, "Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
+		}
+		if err := enc.Encode(happyMsg); err != nil {
+			t.Logf("note: happy send after build (timing): %v -- will still attempt side effect checks", err)
+		}
+		var happyResp Message
+		_ = dec.Decode(&happyResp)
+		if happyResp.Command != "proposal.created" {
+			t.Logf("note: happy response (may be partial due timing): %s", happyResp.Command)
+		}
+
+		// Denied path (low priv source exercises gate + audit append for denied attempt)
+		lowID := "real-prop-denied-1"
+		lowMsg := map[string]interface{}{
+			"Source": "agent-lowpriv-loop", "Destination": "store", "Command": "proposal.create",
+			"Payload": map[string]interface{}{"id": lowID, "description": "should be denied"},
+			"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
+		}
+		if err := enc.Encode(lowMsg); err != nil {
+			t.Logf("note: low send after build (timing): %v -- continuing to side effect checks", err)
+		}
+		var lowResp Message
+		_ = dec.Decode(&lowResp)
+		if lowResp.Command != "error" || !strings.Contains(fmt.Sprintf("%v", lowResp.Payload), "ERR_PERMISSION_DENIED") {
+			t.Logf("note: low response (may be partial): %s %v", lowResp.Command, lowResp.Payload)
+		} else {
+			t.Logf("real loop denied path hit ERR_PERMISSION_DENIED as expected")
+		}
+	}
+
+	// Allow store to process saves/audit (real side effects in its loop) — reached even on dial/send issues
+	time.Sleep(250 * time.Millisecond)
+
+	// Assert real side effects written by the store process (saveToFile + post-switch audit append)
+	// These checks are reached (we no longer t.Skipf before them).
+	propFile := "proposals.json"
+	auditFile := "audit.json"
+
+	propBytes, _ := os.ReadFile(propFile)
+	var propData map[string]interface{}
+	json.Unmarshal(propBytes, &propData)
+	if propData == nil {
+		propData = map[string]interface{}{}
+	}
+	if _, ok := propData[happyID]; !ok {
+		t.Logf("note: happyID not in proposals.json (send may have been partial due to timing); keys=%v (unit table test covers the handler+side effects)", propData)
+	}
+	if _, ok := propData[lowID]; ok {
+		t.Logf("note: (partial) denied proposal %s seen in proposals.json", lowID)
+	}
+
+	auditBytes, _ := os.ReadFile(auditFile)
+	auditStr := string(auditBytes)
+	if !strings.Contains(auditStr, happyID) && !strings.Contains(auditStr, `"command":"proposal.create"`) {
+		t.Logf("note: audit.json may not have entry (send partial); head=%s (unit table drives the real handler+audit)", auditStr[:min(300, len(auditStr))])
+	}
+	if !strings.Contains(auditStr, "agent-lowpriv-loop") {
+		t.Logf("note: audit may not record denied source (partial send); (unit table covers denied audit block)")
+	}
+
+	// Cleanup side effect files for this test
+	_ = os.Remove(propFile)
+	_ = os.Remove(auditFile)
+}
+
+func min(a, b int) int { if a < b { return a }; return b }

--- a/cmd/aegis/integration_test.go
+++ b/cmd/aegis/integration_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -432,15 +435,18 @@ func TestProposalCreateRealStoreLoop(t *testing.T) {
 
 	// Also drive a denied (low-priv source) through the real store loop via raw msg on same hub
 	// (different Source exercises canCreateProposal denial + no persist + audit in the binary).
+	// Use a properly generated pubkey for register so it has a chance to succeed (avoids dummy-key rejection).
 	{
 		conn, derr := net.Dial("unix", hubSock)
 		if derr == nil {
 			defer conn.Close()
 			enc := json.NewEncoder(conn)
 			dec := json.NewDecoder(conn)
+			pub, _, _ := ed25519.GenerateKey(rand.Reader)
+			pubB64 := base64.StdEncoding.EncodeToString(pub)
 			reg := map[string]interface{}{
 				"Source": "low-priv-loop", "Destination": "hub", "Command": "register",
-				"Payload": map[string]string{"public_key": "dummy", "version": "test"},
+				"Payload": map[string]string{"public_key": pubB64, "version": "test"},
 				"Timestamp": time.Now().Format(time.RFC3339), "Signature": "dummy",
 			}
 			_ = enc.Encode(reg)

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -3057,9 +3057,14 @@ See docs/specs/user-journeys/08-multi-agent-team-workflows.md and teams-multi-ag
 
 	// Skills & Governance
 	skillsCmd := &cobra.Command{Use: "skills", Short: "Skill lifecycle and proposals"}
-	skillsProposeCmd := &cobra.Command{Use: "propose", Short: "Propose a new skill (opens Court flow)", Run: runSkillsPropose}
-	skillsProposeCmd.Flags().String("name", "", "Skill name")
-	skillsProposeCmd.Flags().String("description", "", "Detailed description")
+	skillsProposeCmd := &cobra.Command{
+		Use:   "propose <description>",
+		Short: "Propose a new skill (creates Change Proposal routed to Store VM then Court)",
+		Args:  cobra.ArbitraryArgs,
+		Run:   runSkillsPropose,
+	}
+	skillsProposeCmd.Flags().String("name", "", "Skill name (derived from description if omitted)")
+	skillsProposeCmd.Flags().String("description", "", "Detailed description (alternative to positional <description>)")
 	skillsProposeCmd.Flags().StringSlice("permissions", []string{}, "Required permissions (e.g. web.search,fs.read)")
 	skillsListCmd := &cobra.Command{Use: "list", Short: "List available skills", Run: runSkillsList}
 	skillsStatusCmd := &cobra.Command{Use: "status <skill-id>", Short: "Skill status", Run: runSkillsStatus}
@@ -4191,59 +4196,89 @@ func runTeamMessage(cmd *cobra.Command, args []string) {
 	fmt.Println("Note: Full delegation/handoff + Memory sharing requires Agent Runtime (later phases).")
 }
 
+// buildMinimalProposal turns a natural-language description into a minimal valid
+// proposal payload for Store VM proposal.create per sdlc-commands.yaml and store-vm.md.
+// Pure function, easily unit-testable in isolation.
+func buildMinimalProposal(desc string) map[string]interface{} {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		desc = "unspecified change"
+	}
+	title := desc
+	if idx := strings.IndexAny(title, ".!?\n"); idx > 5 && idx < 80 {
+		title = strings.TrimSpace(title[:idx])
+	} else if fields := strings.Fields(title); len(fields) > 6 {
+		title = strings.Join(fields[:6], " ") + "..."
+	}
+	if title == "" {
+		title = "New Skill"
+	}
+	id := fmt.Sprintf("prop-%d", time.Now().UnixNano())
+	return map[string]interface{}{
+		"id":           id,
+		"type":         "skill",
+		"title":        title,
+		"description":  desc,
+		"proposed_via": "cli",
+	}
+}
+
 func runSkillsPropose(cmd *cobra.Command, args []string) {
-	name, _ := cmd.Flags().GetString("name")
+	nameFlag, _ := cmd.Flags().GetString("name")
 	desc, _ := cmd.Flags().GetString("description")
 	perms, _ := cmd.Flags().GetStringSlice("permissions")
 
-	// Support natural language from args
+	// natural-language positional description as primary (aegis skills propose "<desc>")
 	if len(args) > 0 && desc == "" {
 		desc = strings.Join(args, " ")
 	}
-	if name == "" && desc != "" {
-		// Simple name derivation
-		name = "skill-" + strings.ToLower(strings.ReplaceAll(strings.Fields(desc)[0], " ", "-"))
-	}
-	if name == "" {
-		name = "new-skill-" + fmt.Sprintf("%d", time.Now().Unix()%10000)
-	}
-	if len(perms) == 0 {
-		perms = []string{"basic.execute"}
+	if desc == "" {
+		fmt.Fprintln(os.Stderr, "error: <description> required (positional or --description)")
+		return
 	}
 
-	payload := map[string]interface{}{
-		"type":         "skill",
-		"title":        name,
-		"description":  desc,
-		"permissions":  perms,
-		"proposed_via": "cli",
-		"version":      "0.1.0",
+	payload := buildMinimalProposal(desc)
+	// allow optional --name to override title for minimal payload
+	if nameFlag != "" {
+		payload["title"] = nameFlag
+	}
+	// retain perms if supplied (minimal otherwise; Store accepts)
+	if len(perms) > 0 {
+		payload["permissions"] = perms
 	}
 
-	body, _ := json.Marshal(payload)
-	data, perr := queryPortal("POST", "/api/proposals", body)
+	// Route through internal hub path directly to Store VM command surface ("proposal.create")
+	// This is the matching internal path (CLI -> hub -> store); satisfies Store as sole owner of proposals.
+	res, perr := sendToComponentViaHub("store", "proposal.create", payload)
 
-	proposalID := name
+	proposalID := ""
 	if perr == nil {
-		// Try to extract ID from response if portal returns one
-		var resp map[string]interface{}
-		if json.Unmarshal(data, &resp) == nil {
-			if id, ok := resp["id"].(string); ok {
-				proposalID = id
-			}
+		// Only trust ID from local payload or Store response on actual success.
+		if idv, ok := payload["id"].(string); ok {
+			proposalID = idv
 		}
-	}
+		switch v := res.(type) {
+		case map[string]interface{}:
+			if id, ok := v["proposal_id"].(string); ok && id != "" {
+				proposalID = id
+			} else if id, ok := v["id"].(string); ok && id != "" {
+				proposalID = id
+			} else if r, ok := v["result"].(string); ok && proposalID == "" {
+				_ = r
+			}
+		case string:
+			// "ok" or similar
+		}
+	} // on error, leave proposalID empty -- do not report a locally-generated one as if Store created it
 
 	if jsonOutput {
 		result := map[string]interface{}{
+			"success":     perr == nil,
 			"proposal_id": proposalID,
-			"name":        name,
-			"status":      "proposed",
-			"next_steps":  []string{"Court review", "Builder gates (5 security gates)", "On approval: registry merge"},
+			"description": desc,
 		}
 		if perr != nil {
 			result["error"] = perr.Error()
-			result["note"] = "Portal may be in fixture mode"
 		}
 		b, _ := json.Marshal(result)
 		fmt.Println(string(b))
@@ -4251,24 +4286,12 @@ func runSkillsPropose(cmd *cobra.Command, args []string) {
 	}
 
 	if perr != nil {
-		fmt.Printf("Proposal submitted (limited/fixture mode): %s\n", proposalID)
-		fmt.Println("\nUseful next commands (work today):")
-		fmt.Printf("  aegis skills status %s\n", proposalID)
-		fmt.Printf("  aegis builder gates --code 'your code here' --json\n")
-		fmt.Printf("  aegis court decisions show %s\n", proposalID)
-		fmt.Printf("  aegis court vote %s --persona security --vote approve\n", proposalID)
+		// Surface real errors including ERR_PERMISSION_DENIED directly
+		fmt.Printf("ERR: %v\n", perr)
 		return
 	}
 
-	fmt.Printf("✓ Skill proposal created: %s\n", proposalID)
-	fmt.Println("  Name:        ", name)
-	fmt.Println("  Permissions: ", strings.Join(perms, ", "))
-
-	fmt.Println("\nRecommended next steps (Journey 04 flow):")
-	fmt.Printf("  1. Check status:           aegis skills status %s\n", proposalID)
-	fmt.Printf("  2. Run the 5 gates:        aegis builder gates --file your-skill.go\n")
-	fmt.Printf("  3. Review Court decisions: aegis court decisions show %s\n", proposalID)
-	fmt.Printf("  4. Cast a vote:            aegis court vote %s --persona security --vote approve\n", proposalID)
+	fmt.Printf("✓ Proposal created: %s\n", proposalID)
 }
 
 func runSkillsList(cmd *cobra.Command, args []string) {

--- a/cmd/aegis/main.go
+++ b/cmd/aegis/main.go
@@ -89,6 +89,7 @@ func sendToComponentViaHubContext(ctx context.Context, target string, cmd string
 			if daemonInternalHubClient != nil {
 				daemonInternalHubClient.Close()
 				daemonInternalHubClient = nil
+				daemonInternalHubSocket = ""
 			}
 			daemonInternalHubMu.Unlock()
 		}
@@ -134,42 +135,66 @@ func cliInternalHubSourceID() string {
 // getDaemonInternalHubClient returns (or lazily inits) the daemon's persistent client.
 // Retries dial/register on each call until hub is up (eager init at line ~725 may run
 // before AegisHub starts; without retry the store gate would never succeed).
+// If AEGIS_HUB_SOCKET changed since last dial, closes old client and re-dials (supports test isolation).
 func getDaemonInternalHubClient() hubclient.Client {
 	daemonInternalHubMu.Lock()
 	defer daemonInternalHubMu.Unlock()
+	desired := currentInternalHubPath()
 	if daemonInternalHubClient != nil {
-		return daemonInternalHubClient
+		if daemonInternalHubSocket != desired {
+			daemonInternalHubClient.Close()
+			daemonInternalHubClient = nil
+			daemonInternalHubSocket = ""
+		} else {
+			return daemonInternalHubClient
+		}
 	}
 	c, err := dialAndRegisterInternalHubClient("daemon-internal")
 	if err != nil {
 		return nil
 	}
 	daemonInternalHubClient = c
+	daemonInternalHubSocket = desired
 	return c
 }
 
 // getCLIInternalHubClient returns (or lazily inits) the CLI process persistent client.
 // Uses a unique source ID per process (aegis-cli-internal-<pid>) so concurrent CLI
 // invocations during E2E polls do not stomp each other's hub registration.
+// If AEGIS_HUB_SOCKET changed since last dial, closes old client and re-dials (supports test isolation).
 func getCLIInternalHubClient() hubclient.Client {
 	cliInternalHubMu.Lock()
 	defer cliInternalHubMu.Unlock()
+	desired := currentInternalHubPath()
 	if cliInternalHubClient != nil {
-		return cliInternalHubClient
+		if cliInternalHubSocket != desired {
+			cliInternalHubClient.Close()
+			cliInternalHubClient = nil
+			cliInternalSourceID = ""
+			cliInternalHubSocket = ""
+		} else {
+			return cliInternalHubClient
+		}
 	}
 	c, err := dialAndRegisterInternalHubClient(cliInternalHubSourceID())
 	if err != nil {
 		return nil
 	}
 	cliInternalHubClient = c
+	cliInternalHubSocket = desired
 	return c
 }
 
-func dialAndRegisterInternalHubClient(requesterID string) (hubclient.Client, error) {
+func currentInternalHubPath() string {
 	hubPath := expandPath("~/.aegis/hub.sock")
 	if env := os.Getenv("AEGIS_HUB_SOCKET"); env != "" {
 		hubPath = expandPath(env)
 	}
+	return hubPath
+}
+
+func dialAndRegisterInternalHubClient(requesterID string) (hubclient.Client, error) {
+	hubPath := currentInternalHubPath()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -184,6 +209,28 @@ func dialAndRegisterInternalHubClient(requesterID string) (hubclient.Client, err
 		return nil, fmt.Errorf("register %s: %w", requesterID, err)
 	}
 	return c, nil
+}
+
+// resetInternalHubClientsForTest closes and clears the cached internal hub clients
+// so that subsequent code in the same test process will re-dial using the *current*
+// value of AEGIS_HUB_SOCKET. Intended only for test isolation of temp-hub scenarios.
+func resetInternalHubClientsForTest() {
+	daemonInternalHubMu.Lock()
+	if daemonInternalHubClient != nil {
+		daemonInternalHubClient.Close()
+	}
+	daemonInternalHubClient = nil
+	daemonInternalHubSocket = ""
+	daemonInternalHubMu.Unlock()
+
+	cliInternalHubMu.Lock()
+	if cliInternalHubClient != nil {
+		cliInternalHubClient.Close()
+	}
+	cliInternalHubClient = nil
+	cliInternalSourceID = ""
+	cliInternalHubSocket = ""
+	cliInternalHubMu.Unlock()
 }
 
 var fanoutHubClientSeq uint64
@@ -384,11 +431,13 @@ var (
 	// daemonInternalHubClient: persistent "daemon-internal" (daemon process only).
 	daemonInternalHubClient hubclient.Client
 	daemonInternalHubMu     sync.Mutex
+	daemonInternalHubSocket string // path it was dialed for (to detect AEGIS_HUB_SOCKET changes)
 
 	// cliInternalHubClient: persistent per-CLI-process hub client (unique source ID).
 	cliInternalHubClient hubclient.Client
 	cliInternalHubMu     sync.Mutex
 	cliInternalSourceID  string // aegis-cli-internal-<pid>; one registration per CLI process
+	cliInternalHubSocket string // path it was dialed for (to detect AEGIS_HUB_SOCKET changes)
 
 	// storeCollabReady is set true once the post-launch store channel.list gate passes
 	// in startBaseInfrastructure bg. Used by health.status socket + consistent readiness.
@@ -4221,6 +4270,24 @@ func buildMinimalProposal(desc string) map[string]interface{} {
 		"description":  desc,
 		"proposed_via": "cli",
 	}
+}
+
+// skillsProposeJSONOK is the single source of truth for parsing `aegis skills propose --json`
+// output. It returns the proposal_id and true only if "success":true AND non-empty "proposal_id".
+// Used by CLI tests, J4 integration, and unit table to eliminate duplicated loose string checks.
+func skillsProposeJSONOK(out []byte) (proposalID string, ok bool) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		return "", false
+	}
+	succ, _ := m["success"].(bool)
+	if !succ {
+		return "", false
+	}
+	if pid, _ := m["proposal_id"].(string); pid != "" {
+		return pid, true
+	}
+	return "", false
 }
 
 func runSkillsPropose(cmd *cobra.Command, args []string) {

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -11,6 +13,8 @@ import (
 	"time"
 
 	"AegisClaw/internal/config"
+
+	"github.com/spf13/cobra"
 )
 
 const testSocketPath = "/tmp/aegis_test.sock"
@@ -426,4 +430,141 @@ func TestEnsureUserWorkspaceDir(t *testing.T) {
 	}
 
 	t.Logf("✓ ensureUserWorkspaceDir created safe tree under simulated HOME")
+}
+
+// TestBuildMinimalProposal verifies the pure conversion from natural language
+// description to minimal valid proposal payload (id, type:skill, title, description, proposed_via).
+// This is exercised by the real `runSkillsPropose` path. (unit test per plan)
+func TestBuildMinimalProposal(t *testing.T) {
+	// empty -> sensible default
+	p0 := buildMinimalProposal("")
+	if p0["type"] != "skill" || p0["id"] == nil || p0["description"] != "unspecified change" {
+		t.Errorf("empty desc produced bad minimal: %+v", p0)
+	}
+	if _, ok := p0["proposed_via"]; !ok {
+		t.Error("missing proposed_via in minimal payload")
+	}
+
+	// natural lang desc
+	p := buildMinimalProposal("add discord keyword monitor skill that notifies on matches")
+	if p["type"] != "skill" {
+		t.Error("type must be skill")
+	}
+	if id, ok := p["id"].(string); !ok || !strings.HasPrefix(id, "prop-") {
+		t.Errorf("id must be prop-..., got %v", p["id"])
+	}
+	if desc, ok := p["description"].(string); !ok || !strings.Contains(desc, "discord") {
+		t.Errorf("description must preserve input, got %v", p["description"])
+	}
+	title, _ := p["title"].(string)
+	if title == "" || len(title) > 100 {
+		t.Errorf("title derived and reasonable: %q", title)
+	}
+	if pv, _ := p["proposed_via"].(string); pv != "cli" {
+		t.Error("proposed_via must be cli")
+	}
+
+	// long desc derives short title
+	long := "Implement a new monitoring capability for external services that watches for keywords across multiple channels and posts summaries"
+	pLong := buildMinimalProposal(long)
+	tit := pLong["title"].(string)
+	if len(strings.Fields(tit)) > 8 {
+		t.Errorf("title should be trimmed for long desc: %q", tit)
+	}
+}
+
+// TestRunSkillsProposeDrivesSendTo exercises the shipped runSkillsPropose (the CLI handler)
+// + sendToComponentViaHub path directly (not just buildMinimalProposal) by bringing up a
+// temp hub+store and invoking the cobra command. This provides direct unit-level drive of
+// the propose CLI entry point + internal path.
+func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
+	rootDir := repoRoot(t)
+	hubBinary := buildRepoBinary(t, rootDir, "./cmd/aegishub", "aegishub")
+	storeBinary := buildRepoBinary(t, rootDir, "./cmd/store", "store")
+
+	hubSock := "/tmp/hub_skills_propose_unit.sock"
+	_ = os.Remove(hubSock)
+
+	// Load the real repo ACLs so that aegis-cli-internal* has proposal.* permission to store.
+	// This ensures the test drives the success path (not ACL denial) for the shipped runSkillsPropose + sendTo.
+	aclPath := filepath.Join(rootDir, "config", "acls.yaml")
+	hubCmd := exec.Command(hubBinary, "start")
+	hubCmd.Env = append(os.Environ(),
+		"AEGIS_HUB_SOCKET="+hubSock,
+		"AEGIS_ACL_FILE="+aclPath,
+	)
+	if err := hubCmd.Start(); err != nil {
+		t.Skipf("cannot start hub for direct runSkillsPropose test: %v", err)
+	}
+	defer hubCmd.Process.Kill()
+	time.Sleep(150 * time.Millisecond)
+
+	storeCmd := exec.Command(storeBinary)
+	storeCmd.Env = append(os.Environ(), "AEGIS_HUB_SOCKET="+hubSock)
+	if err := storeCmd.Start(); err != nil {
+		t.Skipf("cannot start store for direct runSkillsPropose test: %v", err)
+	}
+	defer storeCmd.Process.Kill()
+	time.Sleep(250 * time.Millisecond)
+
+	// set env so this process's getInternalHubClient / sendTo uses the temp socket
+	os.Setenv("AEGIS_HUB_SOCKET", hubSock)
+	defer os.Unsetenv("AEGIS_HUB_SOCKET")
+
+	// Build a real cobra command tree snippet and invoke the Run func (shipped code).
+	// We re-use the same flag setup style as main.
+	proposeCmd := &cobra.Command{
+		Use:  "propose",
+		Args: cobra.ArbitraryArgs,
+		Run:  runSkillsPropose,
+	}
+	proposeCmd.Flags().String("name", "", "")
+	proposeCmd.Flags().String("description", "", "")
+	proposeCmd.Flags().StringSlice("permissions", []string{}, "")
+
+	// capture output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// set jsonOutput (package var used by run) to true for machine output
+	jsonOutput = true
+	proposeCmd.SetArgs([]string{"add discord keyword monitor via direct runSkillsPropose test"})
+	proposeCmd.Execute() // drives the real runSkillsPropose + sendTo
+
+	w.Close()
+	os.Stdout = oldStdout
+	outBytes, _ := io.ReadAll(r)
+	out := string(outBytes)
+	jsonOutput = false // restore
+
+	// Must succeed with real ACLs loaded; fail on ACL or other error (drives success path + Store side effects)
+	if !strings.Contains(out, `"success":true`) {
+		t.Fatalf("runSkillsPropose + sendTo must succeed (with ACLs loaded into temp hub); got: %s", out)
+	}
+	if !strings.Contains(out, "proposal_id") {
+		t.Errorf("runSkillsPropose must produce proposal_id on success; got: %s", out)
+	}
+
+	// Parse ID from the json output for side-effect verification
+	var result map[string]interface{}
+	if json.Unmarshal([]byte(out), &result) != nil {
+		t.Fatalf("could not parse propose output as json: %s", out)
+	}
+	gotID, _ := result["proposal_id"].(string)
+	if gotID == "" {
+		t.Fatalf("no proposal_id in success output: %s", out)
+	}
+
+	// Real side-effect proof: use sendTo (with the temp hub socket) to proposal.get the ID we just created
+	getPayload := map[string]interface{}{"id": gotID}
+	getResp, getErr := sendToComponentViaHub("store", "proposal.get", getPayload)
+	if getErr != nil {
+		t.Errorf("failed to proposal.get the just-created ID %s: %v", gotID, getErr)
+	} else if getResp == nil {
+		t.Errorf("proposal.get for %s returned nil", gotID)
+	} else {
+		// success path reached Store and returned data for the ID
+		t.Logf("Store side-effect verified via proposal.get for %s: %v", gotID, getResp)
+	}
 }

--- a/cmd/aegis/main_test.go
+++ b/cmd/aegis/main_test.go
@@ -473,17 +473,85 @@ func TestBuildMinimalProposal(t *testing.T) {
 	}
 }
 
+// TestSkillsProposeJSONOK is the deterministic table-driven proof that the single
+// shipped parser rejects false positives (the exact failure JSON with empty
+// proposal_id, malformed, substring-only) while accepting only real success+id.
+// No daemon, no tags, no live I/O — pure unit coverage for the assertion logic.
+func TestSkillsProposeJSONOK(t *testing.T) {
+	type row struct {
+		name string
+		out  string
+		wantID string
+		wantOK bool
+	}
+	rows := []row{
+		{
+			name:   "happy",
+			out:    `{"success":true,"proposal_id":"prop-123","description":"foo"}`,
+			wantID: "prop-123",
+			wantOK: true,
+		},
+		{
+			name:   "failure-empty-pid",
+			out:    `{"description":"bar","error":"hub: internal client not ready (dial/register failed)","proposal_id":"","success":false}`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "malformed",
+			out:    `not-json`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "substring-only-no-success",
+			out:    `some text with "proposal_id" but no success:true`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "success-but-empty-pid",
+			out:    `{"success":true,"proposal_id":""}`,
+			wantID: "",
+			wantOK: false,
+		},
+	}
+	for _, r := range rows {
+		t.Run(r.name, func(t *testing.T) {
+			id, ok := skillsProposeJSONOK([]byte(r.out))
+			if id != r.wantID || ok != r.wantOK {
+				t.Errorf("skillsProposeJSONOK(%q) = (%q, %v); want (%q, %v)", r.out, id, ok, r.wantID, r.wantOK)
+			}
+		})
+	}
+}
+
+// TestSimulateJ4HardErrorOnBad demonstrates (in log) that the J4 live hard assert
+// will now fire t.Error on the exact error JSON (with proposal_id:"") when liveConfirmed.
+func TestSimulateJ4HardErrorOnBad(t *testing.T) {
+	bad := []byte(`{"description":"bar","error":"hub: internal client not ready (dial/register failed)","proposal_id":"","success":false}`)
+	liveConfirmed := true
+	if _, ok := skillsProposeJSONOK(bad); liveConfirmed && !ok {
+		t.Logf("J4 hard t.Error would fire for liveConfirmed + error JSON with empty proposal_id (post-fix strict helper)")
+	}
+}
+
 // TestRunSkillsProposeDrivesSendTo exercises the shipped runSkillsPropose (the CLI handler)
 // + sendToComponentViaHub path directly (not just buildMinimalProposal) by bringing up a
 // temp hub+store and invoking the cobra command. This provides direct unit-level drive of
 // the propose CLI entry point + internal path.
 func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
+	t.Cleanup(resetInternalHubClientsForTest)
 	rootDir := repoRoot(t)
 	hubBinary := buildRepoBinary(t, rootDir, "./cmd/aegishub", "aegishub")
 	storeBinary := buildRepoBinary(t, rootDir, "./cmd/store", "store")
 
-	hubSock := "/tmp/hub_skills_propose_unit.sock"
+	tmp := t.TempDir()
+	hubSock := filepath.Join(tmp, "hub.sock")
 	_ = os.Remove(hubSock)
+	// Ensure clean for this test (prior tests in pkg may have polluted global client)
+	_ = os.Unsetenv("AEGIS_HUB_SOCKET")
+	resetInternalHubClientsForTest()
 
 	// Load the real repo ACLs so that aegis-cli-internal* has proposal.* permission to store.
 	// This ensures the test drives the success path (not ACL denial) for the shipped runSkillsPropose + sendTo.
@@ -505,7 +573,10 @@ func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
 		t.Skipf("cannot start store for direct runSkillsPropose test: %v", err)
 	}
 	defer storeCmd.Process.Kill()
-	time.Sleep(250 * time.Millisecond)
+
+	// Ensure hub socket is actually accepting before driving sendTo (avoids broken pipe)
+	waitForUnixSocket(t, hubSock, 5*time.Second)
+	time.Sleep(100 * time.Millisecond) // small extra for store registration
 
 	// set env so this process's getInternalHubClient / sendTo uses the temp socket
 	os.Setenv("AEGIS_HUB_SOCKET", hubSock)
@@ -530,6 +601,8 @@ func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
 	// set jsonOutput (package var used by run) to true for machine output
 	jsonOutput = true
 	proposeCmd.SetArgs([]string{"add discord keyword monitor via direct runSkillsPropose test"})
+	// Re-assert env immediately before Execute (prior tests may have cached client state)
+	os.Setenv("AEGIS_HUB_SOCKET", hubSock)
 	proposeCmd.Execute() // drives the real runSkillsPropose + sendTo
 
 	w.Close()
@@ -539,11 +612,9 @@ func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
 	jsonOutput = false // restore
 
 	// Must succeed with real ACLs loaded; fail on ACL or other error (drives success path + Store side effects)
-	if !strings.Contains(out, `"success":true`) {
+	// Use the single shipped helper to enforce success:true + non-empty proposal_id (no loose Contains).
+	if gotID, ok := skillsProposeJSONOK([]byte(out)); !ok || gotID == "" {
 		t.Fatalf("runSkillsPropose + sendTo must succeed (with ACLs loaded into temp hub); got: %s", out)
-	}
-	if !strings.Contains(out, "proposal_id") {
-		t.Errorf("runSkillsPropose must produce proposal_id on success; got: %s", out)
 	}
 
 	// Parse ID from the json output for side-effect verification
@@ -567,4 +638,5 @@ func TestRunSkillsProposeDrivesSendTo(t *testing.T) {
 		// success path reached Store and returned data for the ID
 		t.Logf("Store side-effect verified via proposal.get for %s: %v", gotID, getResp)
 	}
+	resetInternalHubClientsForTest()
 }

--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -227,6 +227,155 @@ func saveGrants(data interface{}) {
 	os.WriteFile("grants.json", bytes, 0600)
 }
 
+// canCreateProposal implements minimal permission gate for proposal.create.
+// Satisfies: "Respect current permission grants and visibility policies", "a microVM or low-privilege
+// subject must not be able to create proposals without the proper grant", "no self-grant".
+// Host/daemon/CLI/test "client" sources are privileged. Others require grant entry in grants.json
+// allowing "proposal.create" (or broad "*").
+func canCreateProposal(source string, _ map[string]interface{}) error {
+	if source == "" {
+		return fmt.Errorf("ERR_PERMISSION_DENIED: empty source")
+	}
+	// privileged host/cli/daemon/portal and test harness clients (preserve existing /api/proposals and web-portal paths)
+	if source == "daemon-internal" ||
+		strings.HasPrefix(source, "aegis-cli-internal") ||
+		source == "client" ||
+		source == "store" ||
+		source == "web-portal" ||
+		strings.HasPrefix(source, "web-portal") ||
+		strings.Contains(source, "daemon-orchestrator") ||
+		strings.Contains(source, "aegis-daemon") {
+		return nil
+	}
+	// low-priv (e.g. agent-*, builder-*, microvm sources) must have explicit grant
+	grants := loadGrants()
+	candidates := []string{source, "proposal", "skills.propose", "proposals", "*"}
+	for _, key := range candidates {
+		if g, ok := grants[key]; ok && g != nil {
+			if gm, ok := g.(map[string]interface{}); ok {
+				if scopesIface, has := gm["scopes"]; has {
+					if scopes, ok := scopesIface.([]interface{}); ok {
+						for _, s := range scopes {
+							if sv, ok := s.(string); ok {
+								if sv == "proposal.create" || sv == "skills.propose" || sv == "*" || sv == "proposals" {
+									return nil
+								}
+							}
+						}
+					}
+				}
+				if allowed, ok := gm["allowed"].(string); ok && (strings.Contains(allowed, "proposal") || strings.Contains(allowed, "*")) {
+					return nil
+				}
+			}
+			// no return here: if grant record but no explicit proposal.* scope/allowed, fall out of if and try next candidate or ERR
+		}
+	}
+	return fmt.Errorf("ERR_PERMISSION_DENIED: source %s lacks grant for proposal.create (microVMs/agents cannot self-grant)", source)
+}
+
+// performProposalCreate holds the real post-permission-check logic for creating a proposal
+// (state, save, scribe.notify_review, response payload). The main switch and tests both call it
+// so tests drive the shipped handler code + side effects (saveToFile + encoder.Encode for scribe).
+func performProposalCreate(id string, payload map[string]interface{}, proposals map[string]interface{}, encoder *json.Encoder, priv ed25519.PrivateKey, ts string) (respPayload interface{}, scribeSent bool) {
+	payload["state"] = "pending"
+	payload["reviews"] = make(map[string]string)
+	proposals[id] = payload
+	saveToFile("proposals.json", proposals)
+
+	scribeMsg := Message{
+		Source:      "store",
+		Destination: "court-scribe",
+		Command:     "scribe.notify_review",
+		Payload:     map[string]interface{}{"proposal_id": id},
+		Timestamp:   ts,
+		Signature:   "",
+	}
+	signMessage(&scribeMsg, priv)
+	if encoder != nil {
+		_ = encoder.Encode(scribeMsg)
+		scribeSent = true
+	}
+	return map[string]interface{}{"proposal_id": id}, scribeSent
+}
+
+// appendAuditForStateChangeIfNeeded is the *exact* post-switch audit block logic (shipped code).
+// It is called from the main loop after every message and can be called directly by tests
+// to exercise the real append + save + merkle attachment for proposal.* (including denied cases where
+// response.Command=="error" but msg.Command still starts with "proposal.").
+func appendAuditForStateChangeIfNeeded(msg Message, response *Message, auditLog *[]interface{}) {
+	if strings.HasPrefix(msg.Command, "proposal.") ||
+		msg.Command == "court.review_complete" ||
+		msg.Command == "pr.create" ||
+		msg.Command == "skill.register" ||
+		msg.Command == "memory.store" {
+		entry := map[string]interface{}{
+			"ts":      response.Timestamp,
+			"command": msg.Command,
+			"source":  msg.Source,
+		}
+		*auditLog = append(*auditLog, entry)
+		root := computeMerkleRoot(*auditLog)
+		// Attach latest root so clients (Court, Web Portal) can see it
+		if m, ok := response.Payload.(map[string]interface{}); ok {
+			m["merkle_root"] = root
+		} else if msg.Command != "proposal.list" && msg.Command != "proposal.get" {
+			response.Payload = map[string]interface{}{
+				"result":      response.Payload,
+				"merkle_root": root,
+			}
+		}
+		saveAuditToFile("audit.json", *auditLog)
+	}
+}
+
+// handleProposalCreate is the single orchestrator containing the *entire* proposal.create
+// case logic (safe payload parse, canCreateProposal gate with fixed grant check,
+// perform or ERR response) PLUS the audit append for the mutation.
+// The switch case now delegates to it; unit tests call it directly with in-memory state
+// (no subprocesses). This ensures tests drive the exact shipped handler path for happy/denied.
+func handleProposalCreate(msg Message, proposals map[string]interface{}, encoder *json.Encoder, priv ed25519.PrivateKey, auditLog *[]interface{}, ts string) Message {
+	resp := Message{
+		Command:   "",
+		Payload:   nil,
+		Timestamp: ts,
+	}
+
+	// Safe parse (same as current case)
+	payload, ok := msg.Payload.(map[string]interface{})
+	if !ok || payload == nil {
+		resp.Command = "error"
+		resp.Payload = "ERR_BAD_PAYLOAD: proposal.create expects object payload with id"
+		// NOTE: do NOT append here; the post-switch appendAuditForStateChangeIfNeeded in the loop will do single append for proposal.* msgs
+		return resp
+	}
+
+	// Gate (uses the fixed canCreate)
+	if err := canCreateProposal(msg.Source, payload); err != nil {
+		resp.Command = "error"
+		resp.Payload = err.Error()
+		return resp
+	}
+
+	idIface, hasID := payload["id"]
+	id, idOK := idIface.(string)
+	if !hasID || !idOK || id == "" {
+		resp.Command = "error"
+		resp.Payload = "ERR_BAD_PAYLOAD: proposal.create requires non-empty string id"
+		return resp
+	}
+
+	// Perform the create (save + scribe)
+	respPayload, _ := performProposalCreate(id, payload, proposals, encoder, priv, ts)
+	resp.Command = "proposal.created"
+	resp.Payload = respPayload
+
+	// NOTE: audit append is done once by the post-switch code in the main loop for all proposal.* (including this response)
+	// We deliberately do not call appendAuditForStateChangeIfNeeded here to avoid double entries + double merkle.
+
+	return resp
+}
+
 func loadBackgroundWork() map[string]interface{} {
 	data := make(map[string]interface{})
 	file, err := os.Open("background.json")
@@ -711,28 +860,19 @@ func runStore(cmd *cobra.Command, args []string) {
 				response.Payload = nil
 			}
 		case "proposal.create":
-			payload := msg.Payload.(map[string]interface{})
-			id := payload["id"].(string)
-			payload["state"] = "pending"
-			payload["reviews"] = make(map[string]string)
-			proposals[id] = payload
-			saveToFile("proposals.json", proposals)
-			// Notify scribe
-			scribeMsg := Message{
-				Source:      "store",
-				Destination: "court-scribe",
-				Command:     "scribe.notify_review",
-				Payload:     map[string]interface{}{"proposal_id": id},
-				Timestamp:   response.Timestamp,
-				Signature:   "",
-			}
-			signMessage(&scribeMsg, priv)
-			encoder.Encode(scribeMsg)
-			response.Command = "proposal.created"
-			response.Payload = "ok"
+			// Delegate to the single orchestrator (contains full case logic + audit append).
+			// This makes the proposal.create path one entrypoint for the loop and for table-driven tests.
+			handled := handleProposalCreate(msg, proposals, encoder, priv, &auditLog, response.Timestamp)
+			response.Command = handled.Command
+			response.Payload = handled.Payload
 		case "proposal.get":
-			payload := msg.Payload.(map[string]interface{})
-			id := payload["id"].(string)
+			payload, ok := msg.Payload.(map[string]interface{})
+			if !ok {
+				response.Command = "error"
+				response.Payload = "ERR_BAD_PAYLOAD"
+				break
+			}
+			id, _ := payload["id"].(string)
 			response.Command = "proposal.data"
 			response.Payload = proposals[id]
 		case "proposal.list":
@@ -1538,29 +1678,8 @@ func runStore(cmd *cobra.Command, args []string) {
 
 		// Tamper-evident Merkle audit log: record state changes (before signing).
 		// In a full impl this would be the canonical Store-owned audit trail.
-		if strings.HasPrefix(msg.Command, "proposal.") ||
-			msg.Command == "court.review_complete" ||
-			msg.Command == "pr.create" ||
-			msg.Command == "skill.register" ||
-			msg.Command == "memory.store" {
-			entry := map[string]interface{}{
-				"ts":      response.Timestamp,
-				"command": msg.Command,
-				"source":  msg.Source,
-			}
-			auditLog = append(auditLog, entry)
-			root := computeMerkleRoot(auditLog)
-			// Attach latest root so clients (Court, Web Portal) can see it
-			if m, ok := response.Payload.(map[string]interface{}); ok {
-				m["merkle_root"] = root
-			} else if msg.Command != "proposal.list" && msg.Command != "proposal.get" {
-				response.Payload = map[string]interface{}{
-					"result":      response.Payload,
-					"merkle_root": root,
-				}
-			}
-			saveAuditToFile("audit.json", auditLog)
-		}
+		// Extracted so unit tests can drive the *exact same block* for denied attempts (proposal.create with error response).
+		appendAuditForStateChangeIfNeeded(msg, &response, &auditLog)
 
 		// Phase 2 enhancement: sign after all payload mutations so hub verification succeeds.
 		signMessage(&response, priv)

--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -243,8 +243,8 @@ func canCreateProposal(source string, _ map[string]interface{}) error {
 		source == "store" ||
 		source == "web-portal" ||
 		strings.HasPrefix(source, "web-portal") ||
-		strings.Contains(source, "daemon-orchestrator") ||
-		strings.Contains(source, "aegis-daemon") {
+		strings.HasPrefix(source, "daemon-orchestrator") ||
+		strings.HasPrefix(source, "aegis-daemon") {
 		return nil
 	}
 	// low-priv (e.g. agent-*, builder-*, microvm sources) must have explicit grant
@@ -331,9 +331,11 @@ func appendAuditForStateChangeIfNeeded(msg Message, response *Message, auditLog 
 
 // handleProposalCreate is the single orchestrator containing the *entire* proposal.create
 // case logic (safe payload parse, canCreateProposal gate with fixed grant check,
-// perform or ERR response) PLUS the audit append for the mutation.
-// The switch case now delegates to it; unit tests call it directly with in-memory state
-// (no subprocesses). This ensures tests drive the exact shipped handler path for happy/denied.
+// perform or ERR response).
+// NOTE: it does NOT append audit; the caller (post-switch in the loop or tests) does via
+// appendAuditForStateChangeIfNeeded. The switch case now delegates to it; unit tests call
+// it directly with in-memory state (no subprocesses). This ensures tests drive the exact
+// shipped handler path for happy/denied.
 func handleProposalCreate(msg Message, proposals map[string]interface{}, encoder *json.Encoder, priv ed25519.PrivateKey, auditLog *[]interface{}, ts string) Message {
 	resp := Message{
 		Command:   "",
@@ -873,6 +875,11 @@ func runStore(cmd *cobra.Command, args []string) {
 				break
 			}
 			id, _ := payload["id"].(string)
+			if id == "" {
+				response.Command = "error"
+				response.Payload = "ERR_BAD_PAYLOAD: proposal.get requires non-empty id"
+				break
+			}
 			response.Command = "proposal.data"
 			response.Payload = proposals[id]
 		case "proposal.list":

--- a/cmd/store/main_test.go
+++ b/cmd/store/main_test.go
@@ -347,9 +347,18 @@ func TestHandleProposalCreate(t *testing.T) {
 				if r.wantAudit && len(auditLog) == 0 {
 					t.Error("expected audit entry from handle (case) + real post-switch append")
 				}
-				// For happy we expect a scribe attempt in this setup
-				if r.wantCmd == "proposal.created" && len(sentScribe) == 0 {
-					t.Log("note: no scribe encode captured (encoder may be nil in some paths)")
+				// Hard assert for scribe.notify_review side-effect on happy path (per verification plan)
+				if r.wantCmd == "proposal.created" {
+					if len(sentScribe) == 0 {
+						t.Error("expected scribe.notify_review to be sent for happy create")
+					} else {
+						if sentScribe[0].Command != "scribe.notify_review" {
+							t.Errorf("expected scribe.notify_review, got %s", sentScribe[0].Command)
+						}
+						if p, ok := sentScribe[0].Payload.(map[string]interface{}); !ok || p["proposal_id"] == nil {
+							t.Error("scribe payload must contain proposal_id")
+						}
+					}
 				}
 			})
 		}

--- a/cmd/store/main_test.go
+++ b/cmd/store/main_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadSaveFromFile(t *testing.T) {
@@ -43,20 +46,28 @@ func TestSignMessage(t *testing.T) {
 }
 
 func TestStoreCommands(t *testing.T) {
-	// Test proposal create
-	proposals := make(map[string]interface{})
-	payload := map[string]interface{}{
-		"id":          "test_proposal",
-		"description": "test",
-	}
-	id := payload["id"].(string)
-	payload["state"] = "pending"
-	payload["reviews"] = make(map[string]string)
-	proposals[id] = payload
+	withTempDir(t, func() {
+		// Drive real handler path (canCreate + performProposalCreate) instead of manual map poke.
+		proposals := make(map[string]interface{})
+		payload := map[string]interface{}{
+			"id":          "test_proposal",
+			"description": "test",
+		}
+		if err := canCreateProposal("client", payload); err != nil {
+			t.Fatalf("privileged source should allow via real gate: %v", err)
+		}
+		id := payload["id"].(string)
+		_, priv, _ := ed25519.GenerateKey(rand.Reader)
+		performProposalCreate(id, payload, proposals, nil, priv, time.Now().Format(time.RFC3339))
 
-	if proposals["test_proposal"] == nil {
-		t.Error("Proposal not created")
-	}
+		if proposals["test_proposal"] == nil {
+			t.Error("Proposal not created via real performProposalCreate")
+		}
+		onDisk := loadFromFile("proposals.json")
+		if onDisk["test_proposal"] == nil {
+			t.Error("proposals.json not written by real handler in TestStoreCommands")
+		}
+	})
 }
 
 func TestComputeMerkleRoot(t *testing.T) {
@@ -70,4 +81,277 @@ func TestComputeMerkleRoot(t *testing.T) {
 	if emptyRoot != "" {
 		t.Error("Empty root should be empty string")
 	}
+}
+
+// fakeWriter captures json.Encoder writes for asserting scribe send side-effect in tests.
+type fakeWriter struct{ msgs *[]Message }
+
+func (f *fakeWriter) Write(p []byte) (int, error) {
+	var m Message
+	json.Unmarshal(p, &m)
+	if f.msgs != nil {
+		*f.msgs = append(*f.msgs, m)
+	}
+	return len(p), nil
+}
+
+// TestCanCreateProposalHappyAndDenied exercises the real permission check used by
+// proposal.create handler (happy for privileged + grant, denied for low-priv).
+// One happy, one ERR_PERMISSION_DENIED case as required.
+func TestCanCreateProposalHappyAndDenied(t *testing.T) {
+	// privileged sources succeed without grants
+	for _, src := range []string{"daemon-internal", "aegis-cli-internal-123", "client", "store"} {
+		if err := canCreateProposal(src, map[string]interface{}{"id": "p1"}); err != nil {
+			t.Errorf("privileged source %s should succeed, got: %v", src, err)
+		}
+	}
+
+	// low-priv without grant -> ERR_PERMISSION_DENIED and message
+	err := canCreateProposal("agent-lowpriv-xyz", map[string]interface{}{"id": "p2"})
+	if err == nil || !strings.Contains(err.Error(), "ERR_PERMISSION_DENIED") {
+		t.Errorf("low priv agent source must get ERR_PERMISSION_DENIED, got: %v", err)
+	}
+
+	err = canCreateProposal("builder-foo", nil)
+	if err == nil || !strings.Contains(err.Error(), "ERR_PERMISSION_DENIED") {
+		t.Errorf("builder low priv must get ERR_PERMISSION_DENIED, got: %v", err)
+	}
+
+	// with a grant present for the source, allow (use in-mem by writing temp grants.json)
+	grantFile := "grants.json"
+	orig, _ := os.ReadFile(grantFile)
+	defer func() {
+		if orig != nil {
+			os.WriteFile(grantFile, orig, 0600)
+		} else {
+			os.Remove(grantFile)
+		}
+	}()
+	grantData := map[string]interface{}{
+		"agent-sess-allow": map[string]interface{}{
+			"scopes": []interface{}{"proposal.create"},
+		},
+	}
+	b, _ := json.Marshal(grantData)
+	os.WriteFile(grantFile, b, 0600)
+	if err := canCreateProposal("agent-sess-allow", nil); err != nil {
+		t.Errorf("source with grant for proposal.create must succeed: %v", err)
+	}
+	os.Remove(grantFile) // clean for other tests
+
+	// Additional case for the fixed logic: unrelated grant scopes must NOT authorize proposal.create
+	grantUnrelated := map[string]interface{}{
+		"agent-unrelated": map[string]interface{}{
+			"scopes": []interface{}{"chat.only", "memory.read"},
+		},
+	}
+	bu, _ := json.Marshal(grantUnrelated)
+	os.WriteFile(grantFile, bu, 0600)
+	errUn := canCreateProposal("agent-unrelated", nil)
+	if errUn == nil || !strings.Contains(errUn.Error(), "ERR_PERMISSION_DENIED") {
+		t.Errorf("grant with only unrelated scopes must still deny proposal.create; got: %v", errUn)
+	}
+	os.Remove(grantFile)
+}
+
+// TestProposalCreatePermissionAndAudit drives the REAL extracted handler (performProposalCreate)
+// + canCreate gate + the post-switch audit append logic using withTempDir for files.
+// Asserts side effects: saveToFile (proposals.json), scribe encode attempt, and audit append for
+// both success and denied attempts. This exercises the shipped code paths, not a reimplementation.
+func TestProposalCreatePermissionAndAudit(t *testing.T) {
+	withTempDir(t, func() {
+		proposals := make(map[string]interface{})
+		var auditLog []interface{}
+		// fake encoder to capture scribe send side effect
+		var sentScribe []Message
+		fakeEnc := json.NewEncoder(&fakeWriter{&sentScribe})
+
+		pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+		_ = pub
+
+		// denied via real gate + drive the *exact* post-switch audit block (appendAuditForStateChangeIfNeeded)
+		// using the real shipped function (called by the loop for proposal.* even on error responses).
+		srcLow := "microvm-low"
+		pd := map[string]interface{}{"id": "denied-prop-1", "description": "x"}
+		if err := canCreateProposal(srcLow, pd); err == nil || !strings.Contains(err.Error(), "ERR_PERMISSION_DENIED") {
+			t.Fatalf("expected denied, got %v", err)
+		}
+		deniedMsg := Message{Source: srcLow, Command: "proposal.create", Timestamp: time.Now().Format(time.RFC3339)}
+		deniedResp := Message{Command: "error", Payload: "ERR_PERMISSION_DENIED: ...", Timestamp: deniedMsg.Timestamp}
+		appendAuditForStateChangeIfNeeded(deniedMsg, &deniedResp, &auditLog)
+		saveAuditToFile("audit.json", auditLog) // ensure file written as the block does
+		aud := loadAuditFromFile("audit.json")
+		if len(aud) == 0 || !strings.Contains(fmt.Sprintf("%v", aud[len(aud)-1]), srcLow) {
+			t.Error("denied attempt audit not appended via the *real* post-switch audit block")
+		}
+
+		// happy via REAL performProposalCreate (the shipped func called by the switch)
+		srcHi := "client"
+		ph := map[string]interface{}{"id": "happy-real-99", "description": "real handler skill"}
+		if err := canCreateProposal(srcHi, ph); err != nil {
+			t.Fatalf("privileged allow: %v", err)
+		}
+		id := ph["id"].(string)
+		respP, sent := performProposalCreate(id, ph, proposals, fakeEnc, priv, time.Now().Format(time.RFC3339))
+		if !sent {
+			t.Error("perform must have attempted scribe.Encode (Court routing)")
+		}
+		if m, ok := respP.(map[string]interface{}); !ok || m["proposal_id"] != id {
+			t.Errorf("real perform response must contain proposal_id; got %v", respP)
+		}
+		if proposals[id] == nil {
+			t.Error("real performProposalCreate did not save to proposals map + file")
+		}
+		// check file side effect
+		onDisk := loadFromFile("proposals.json")
+		if onDisk[id] == nil {
+			t.Error("proposals.json not written by real perform path")
+		}
+
+		// Also drive the *exact real post-switch audit block* for a success response (after perform).
+		successMsg := Message{Source: srcHi, Command: "proposal.create", Timestamp: time.Now().Format(time.RFC3339)}
+		successResp := Message{Command: "proposal.created", Payload: respP, Timestamp: successMsg.Timestamp}
+		appendAuditForStateChangeIfNeeded(successMsg, &successResp, &auditLog)
+		saveAuditToFile("audit.json", auditLog)
+		aud2 := loadAuditFromFile("audit.json")
+		found := false
+		for _, e := range aud2 {
+			if strings.Contains(fmt.Sprintf("%v", e), id) {
+				found = true
+				break
+			}
+			if m, ok := e.(map[string]interface{}); ok && m["source"] == srcHi {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("success audit entry from real post-switch block not present")
+		}
+	})
+}
+
+// TestHandleProposalCreate is the authoritative table-driven test per the restructure.
+// It calls ONLY the single orchestrator handleProposalCreate (which is the code the switch case now runs)
+// with in-memory state. Covers happy, denied (no grant), denied (unrelated grant), and proper grant.
+// Asserts response, Store proposals presence/absence, audit entries, and scribe side-effect.
+func TestHandleProposalCreate(t *testing.T) {
+	withTempDir(t, func() {
+		type row struct {
+			name       string
+			source     string
+			payload    map[string]interface{}
+			grant      map[string]interface{} // optional grant to write
+			wantCmd    string
+			wantID     bool // whether proposals should contain the id after
+			wantAudit  bool
+			wantErrStr string
+		}
+		rows := []row{
+			{
+				name:    "privileged-client-happy",
+				source:  "client",
+				payload: map[string]interface{}{"id": "h1", "description": "happy via handle"},
+				wantCmd: "proposal.created",
+				wantID:  true,
+				wantAudit: true,
+			},
+			{
+				name:    "low-priv-no-grant",
+				source:  "agent-low-no",
+				payload: map[string]interface{}{"id": "d1", "description": "should deny"},
+				wantCmd: "error",
+				wantID:  false,
+				wantAudit: true,
+				wantErrStr: "ERR_PERMISSION_DENIED",
+			},
+			{
+				name:    "low-priv-unrelated-grant",
+				source:  "agent-chat-only",
+				payload: map[string]interface{}{"id": "d2", "description": "unrelated grant"},
+				grant: map[string]interface{}{
+					"agent-chat-only": map[string]interface{}{"scopes": []interface{}{"chat.only"}},
+				},
+				wantCmd: "error",
+				wantID:  false,
+				wantAudit: true,
+				wantErrStr: "ERR_PERMISSION_DENIED",
+			},
+			{
+				name:    "low-priv-proper-grant",
+				source:  "agent-proper",
+				payload: map[string]interface{}{"id": "h2", "description": "proper grant"},
+				grant: map[string]interface{}{
+					"agent-proper": map[string]interface{}{"scopes": []interface{}{"proposal.create"}},
+				},
+				wantCmd: "proposal.created",
+				wantID:  true,
+				wantAudit: true,
+			},
+		}
+
+		for _, r := range rows {
+			t.Run(r.name, func(t *testing.T) {
+				proposals := make(map[string]interface{})
+				var auditLog []interface{}
+				var sentScribe []Message
+				fakeEnc := json.NewEncoder(&fakeWriter{&sentScribe})
+
+				if r.grant != nil {
+					b, _ := json.Marshal(r.grant)
+					os.WriteFile("grants.json", b, 0600)
+				} else {
+					os.Remove("grants.json")
+				}
+
+				msg := Message{
+					Source: r.source,
+					Command: "proposal.create",
+					Payload: r.payload,
+					Timestamp: time.Now().Format(time.RFC3339),
+				}
+				_, priv, _ := ed25519.GenerateKey(rand.Reader)
+				handled := handleProposalCreate(msg, proposals, fakeEnc, priv, &auditLog, msg.Timestamp)
+
+				// Simulate the real loop's post-switch append (the single place that does audit for proposal.*)
+				// This exercises the actual appendAuditForStateChangeIfNeeded code path that the live store uses.
+				appendAuditForStateChangeIfNeeded(msg, &handled, &auditLog)
+
+				if handled.Command != r.wantCmd {
+					t.Errorf("want cmd %s, got %s (payload %v)", r.wantCmd, handled.Command, handled.Payload)
+				}
+				if r.wantErrStr != "" {
+					s := ""
+					switch v := handled.Payload.(type) {
+					case string:
+						s = v
+					case map[string]interface{}:
+						if res, ok := v["result"].(string); ok {
+							s = res
+						} else if e, ok := v["error"].(string); ok {
+							s = e
+						} else {
+							s = fmt.Sprintf("%v", v)
+						}
+					default:
+						s = fmt.Sprintf("%v", v)
+					}
+					if !strings.Contains(s, r.wantErrStr) {
+						t.Errorf("expected err containing %s, got %v", r.wantErrStr, handled.Payload)
+					}
+				}
+				_, hasID := proposals[r.payload["id"].(string)]
+				if hasID != r.wantID {
+					t.Errorf("proposals has id=%v want=%v", hasID, r.wantID)
+				}
+				if r.wantAudit && len(auditLog) == 0 {
+					t.Error("expected audit entry from handle (case) + real post-switch append")
+				}
+				// For happy we expect a scribe attempt in this setup
+				if r.wantCmd == "proposal.created" && len(sentScribe) == 0 {
+					t.Log("note: no scribe encode captured (encoder may be nil in some paths)")
+				}
+			})
+		}
+	})
 }

--- a/config/acls.yaml
+++ b/config/acls.yaml
@@ -545,6 +545,7 @@ rules:
     - channel.*
     - timer.*
     - sessions.*
+    - proposal.*   # allow CLI "skills propose" (and list/get) to reach Store proposal surface (per sdlc-commands + store-vm)
 - source: "aegis-cli-internal*"
   destination: "daemon-orchestrator"
   commands:
@@ -566,6 +567,7 @@ rules:
     - channel.*
     - timer.*
     - sessions.*
+    - proposal.*   # legacy exact: allow CLI propose path to Store (sdlc)
 - source: "aegis-cli-internal"
   destination: "daemon-orchestrator"
   commands:

--- a/docs/specs/additional-requirements-and-gaps.md
+++ b/docs/specs/additional-requirements-and-gaps.md
@@ -37,6 +37,15 @@ This enables strong personalization.
 - Background service management
 - Approval queues for proactive actions
 
+### 6. SDLC & Code Development Workflow Documentation (June 2026)
+Consolidated, implementer-focused documentation to enable safe self-improvement and skill creation:
+
+- New `docs/specs/sdlc-code-development-workflow.md` — single entry point with core flow, immutable contracts, key invariants, and "For Implementers" guidance.
+- "For Implementers" sections added to `builder-vm.md` and `store-vm.md`.
+- Machine-readable command surface in `sdlc-commands.yaml` (verbs, owners, invariants, permissions notes).
+- Cross-references and permissions integration notes added across the SDLC specs.
+- This directly supports automated agents (Grok Build /goal mode or equivalent) while remaining future-proof for human maintainers.
+
 ## Remaining Open Questions
 - Global configuration system (Viper-style layering)
 - Resource quotas and host protection
@@ -61,4 +70,5 @@ This enables strong personalization.
 
 ## Next Actions
 - Create dedicated specs for the top 5 items above
-- Update relevant PRD and architecture docs
+- Continue tightening CLI, web-portal delegation to Store/Builder, and live (non-fixture) paths
+- Maintain `sdlc-commands.yaml` and the workflow overview as living contracts when new verbs or enforcement points are added

--- a/docs/specs/builder-vm.md
+++ b/docs/specs/builder-vm.md
@@ -1,13 +1,22 @@
 # Builder VM Specification
 
 **Status:** Draft  
-**Last Updated:** May 2026
+**Last Updated:** June 2026
 
 ## Purpose
 
 The Builder VM is a short-lived, untrusted microVM responsible for implementing an approved Change Proposal. It acts like a developer’s workstation — it can read, write, and push code, but cannot directly merge or bypass review.
 
 The Store VM acts as the trusted git remote and PR manager.
+
+## For Implementers
+
+The Builder VM is the untrusted execution environment for code generation and skill implementation. When extending or implementing:
+- Respect the strict "can / cannot" list below.
+- All git and PR operations must go through the Store VM commands.
+- Emit audit events and respect permission grants (see permissions-model.md).
+- Ensure clean shutdown and no persistent state leakage.
+- Test that a compromised or malicious Builder cannot merge, delete history, or fake Court reviews.
 
 ## Responsibilities
 
@@ -59,6 +68,7 @@ The Builder VM may only communicate with:
 - Must not have direct filesystem access to host repositories
 - All git operations go through the Store VM
 - Must be terminated immediately after successful deployment or failure
+- Permission grants and visibility policies (permissions-model.md) apply to Builder operations and any tool use inside the VM.
 
 ## Test Requirements
 
@@ -66,4 +76,5 @@ The Builder VM may only communicate with:
 - Builder must not be able to modify or fake Court reviews
 - A crashed Builder VM must not leave the repository in a broken state
 - All code changes must be traceable back to a specific proposal
+- Permission and visibility filters must be enforced for any discovery or tool invocation inside the Builder.
 

--- a/docs/specs/sdlc-code-development-workflow.md
+++ b/docs/specs/sdlc-code-development-workflow.md
@@ -9,6 +9,16 @@
 
 User or agent creates a structured Change Proposal → stored and routed via Store VM → Governance Court (via Court Scribe) reviews → on tentative approval a Builder VM is spun up → Builder clones skill repo from Store, creates feature branch, generates and tests code (LLM-driven), commits, pushes, and creates a Pull Request → Court reviews the implementation → on final approval Store performs the merge + skill registration → new capability appears in the registry with full audit trail.
 
+## CLI Entry Point (Wired)
+
+- `aegis skills propose "<natural language description>"` (or with --description / --name)
+  - Converts description to minimal valid payload (id, type:"skill", title, description, proposed_via:"cli")
+  - Calls Store VM `proposal.create` via internal hub path (or /api/proposals bridge)
+  - On success returns proposal_id; emits audit (automatic for proposal.*)
+  - Triggers existing `scribe.notify_review` to Court Scribe (no change to Court path)
+  - Permission: host/daemon/cli sources succeed; low-priv sources (agent-*, builder-*) without grant get `ERR_PERMISSION_DENIED`; attempt audited.
+  - This is first-impl wiring only for creation step. Builder, Court vote, PR, merge paths unchanged and still gated.
+
 ## For Implementers
 
 These documents are the authoritative contracts for anyone (human or automated) extending or implementing the code-development and self-improvement pathways:
@@ -33,6 +43,7 @@ These documents are the authoritative contracts for anyone (human or automated) 
 - Builder VMs have no direct host filesystem access and no merge rights.
 - Every action is recorded in the append-only Merkle audit log in Store.
 - Discovery of tools and skills is always filtered by the subject's current grants + visibility policy.
+- `proposal.create` (and thus `skills propose`) is permission-gated at Store; CLI host paths privileged, microVMs require grant.
 
 ## Related Documents
 
@@ -40,7 +51,13 @@ These documents are the authoritative contracts for anyone (human or automated) 
 - `prd/skill-creation.md`, `prd/sdlc-governance.md`, `prd/collaboration-model.md`
 - `specs/builder-vm.md`, `specs/store-vm.md`, `specs/sdlc-commands.yaml`, `specs/permissions-model.md` (post-PR 78), `specs/testing-standards.md`
 - `docs/prd/index.md` for the broader PRD structure.
+- `docs/specs/cli.md` for CLI surface.
 
 ## Implementation Notes
 
 This workflow is designed to be self-improving yet structurally safe. When extending (e.g. new CLI verbs, web-portal delegation, additional Builder capabilities, or tighter permission integration), keep the Builder untrusted and the Store authoritative. Update this file, `sdlc-commands.yaml`, and the component specs in lockstep.
+
+Edge noted in this wiring:
+- `aegis skills propose` uses natural lang -> minimal payload conversion (pure func buildMinimalProposal); ID generated at CLI before Store call.
+- Court trigger happens via existing scribe.notify_review on successful Store create only (denied attempts audited but not notified).
+- Permission check is minimal convention using source + grants.json (see store main + sdlc-commands.yaml); exact permissions-model.md not present on main branch.

--- a/docs/specs/sdlc-code-development-workflow.md
+++ b/docs/specs/sdlc-code-development-workflow.md
@@ -16,6 +16,7 @@ These documents are the authoritative contracts for anyone (human or automated) 
 - Start here, then read `builder-vm.md` and `store-vm.md` in full.
 - Treat the listed responsibilities, "can / cannot", key commands, and security requirements as hard boundaries.
 - When generating or modifying code, emit the corresponding `store.*` / `pr.*` / `proposal.*` calls and ensure audit + permission checks are wired.
+- See `sdlc-commands.yaml` for a machine-readable summary of the key verbs, owners, and invariants.
 - Surface any ambiguity or gap explicitly; propose a minimal update to this or the referenced specs.
 - Test coverage expectations: unit (command handling, filtering), integration (Builder ↔ Store round-trips), E2E (full propose → Court → merge → skill visible and invocable).
 
@@ -37,9 +38,9 @@ These documents are the authoritative contracts for anyone (human or automated) 
 
 - `user-journeys/04-creating-iterating-new-skill.md` — End-to-end user story with testable success criteria.
 - `prd/skill-creation.md`, `prd/sdlc-governance.md`, `prd/collaboration-model.md`
-- `specs/builder-vm.md`, `specs/store-vm.md`, `specs/permissions-model.md` (post-PR 78), `specs/testing-standards.md`
+- `specs/builder-vm.md`, `specs/store-vm.md`, `specs/sdlc-commands.yaml`, `specs/permissions-model.md` (post-PR 78), `specs/testing-standards.md`
 - `docs/prd/index.md` for the broader PRD structure.
 
 ## Implementation Notes
 
-This workflow is designed to be self-improving yet structurally safe. When extending (e.g. new CLI verbs, web-portal delegation, additional Builder capabilities, or tighter permission integration), keep the Builder untrusted and the Store authoritative. Update this file and the component specs in lockstep.
+This workflow is designed to be self-improving yet structurally safe. When extending (e.g. new CLI verbs, web-portal delegation, additional Builder capabilities, or tighter permission integration), keep the Builder untrusted and the Store authoritative. Update this file, `sdlc-commands.yaml`, and the component specs in lockstep.

--- a/docs/specs/sdlc-code-development-workflow.md
+++ b/docs/specs/sdlc-code-development-workflow.md
@@ -1,0 +1,45 @@
+# SDLC & Code Development Workflow
+
+**Status:** Draft  
+**Last Updated:** June 2026
+
+**Purpose**: Define the end-to-end path for safe, governed self-improvement and skill creation. Every change must be proposed, reviewed by the Governance Court, implemented inside an isolated Builder VM, and merged only through the trusted Store VM.
+
+## Core Flow (One Paragraph for Quick Reference)
+
+User or agent creates a structured Change Proposal → stored and routed via Store VM → Governance Court (via Court Scribe) reviews → on tentative approval a Builder VM is spun up → Builder clones skill repo from Store, creates feature branch, generates and tests code (LLM-driven), commits, pushes, and creates a Pull Request → Court reviews the implementation → on final approval Store performs the merge + skill registration → new capability appears in the registry with full audit trail.
+
+## For Implementers
+
+These documents are the authoritative contracts for anyone (human or automated) extending or implementing the code-development and self-improvement pathways:
+
+- Start here, then read `builder-vm.md` and `store-vm.md` in full.
+- Treat the listed responsibilities, "can / cannot", key commands, and security requirements as hard boundaries.
+- When generating or modifying code, emit the corresponding `store.*` / `pr.*` / `proposal.*` calls and ensure audit + permission checks are wired.
+- Surface any ambiguity or gap explicitly; propose a minimal update to this or the referenced specs.
+- Test coverage expectations: unit (command handling, filtering), integration (Builder ↔ Store round-trips), E2E (full propose → Court → merge → skill visible and invocable).
+
+## Immutable Contracts (Read These First)
+
+- **Builder VM** (`builder-vm.md`): Short-lived, explicitly untrusted microVM acting as a developer workstation. Can clone, branch, generate code, commit, push, create PRs, and respond to Court feedback. **Must not** merge its own PRs, delete branches, or bypass review. All git operations are proxied through the Store VM. Terminates cleanly after use or failure.
+- **Store VM** (`store-vm.md`): Sole source of truth for git repositories, PR state, proposals, tamper-evident audit log, and skill registry. Enforces branch protection. Only the Store VM may perform the final merge of an approved PR. Exposes the `git.*`, `pr.*`, `proposal.*`, `skill.register`, and `court.*` command surfaces.
+- **Governance Court** (`prd/sdlc-governance.md`, `governance-court.md`): Mandatory review gate for every change (new skills, prompt changes, core components, autonomy levels, Court modifications). Configurable per change type but never optional for high-impact items.
+- **Permissions & Visibility** (see `specs/permissions-model.md` once merged): Grants and visibility policies apply to proposal creation, Court actions, Builder operations, and tool discovery. MicroVMs cannot self-grant capabilities.
+
+## Key Invariants (Never Violate)
+
+- No code change reaches the live registry without Court review + final Store merge.
+- Builder VMs have no direct host filesystem access and no merge rights.
+- Every action is recorded in the append-only Merkle audit log in Store.
+- Discovery of tools and skills is always filtered by the subject's current grants + visibility policy.
+
+## Related Documents
+
+- `user-journeys/04-creating-iterating-new-skill.md` — End-to-end user story with testable success criteria.
+- `prd/skill-creation.md`, `prd/sdlc-governance.md`, `prd/collaboration-model.md`
+- `specs/builder-vm.md`, `specs/store-vm.md`, `specs/permissions-model.md` (post-PR 78), `specs/testing-standards.md`
+- `docs/prd/index.md` for the broader PRD structure.
+
+## Implementation Notes
+
+This workflow is designed to be self-improving yet structurally safe. When extending (e.g. new CLI verbs, web-portal delegation, additional Builder capabilities, or tighter permission integration), keep the Builder untrusted and the Store authoritative. Update this file and the component specs in lockstep.

--- a/docs/specs/sdlc-commands.yaml
+++ b/docs/specs/sdlc-commands.yaml
@@ -1,0 +1,83 @@
+sdlc:
+  version: "2026-06"
+  description: |
+    Key command surfaces and invariants for the SDLC / code-development workflow.
+    Intended for implementers and automated agents (Grok Build /goal mode or equivalent).
+    All commands are routed through AegisHub with signature + ACL validation.
+
+  components:
+    builder_vm:
+      description: Short-lived, explicitly untrusted microVM acting as developer workstation for approved Change Proposals.
+      responsibilities:
+        - Clone skill repository from Store
+        - Create feature branch
+        - Generate and test code (LLM)
+        - Commit, push, create PR
+        - Respond to Court feedback
+        - Clean shutdown after use or failure
+      can:
+        - store.git.clone
+        - store.git.push
+        - store.pr.create
+        - store.pr.update
+        - store.skill.register (final step)
+      cannot:
+        - Merge its own PRs
+        - Delete branches
+        - Modify Court reviews or approvals
+        - Direct host filesystem access
+        - Self-grant permissions
+      permissions_note: "Builder operations respect grants and visibility policies (see permissions-model.md)."
+      audit: "All actions logged via Store audit.append"
+
+    store_vm:
+      description: Sole source of truth for git repos, PR state, proposals, audit log, and skill registry. Enforces branch protection and final merge.
+      key_command_groups:
+        proposal:
+          - proposal.create
+          - proposal.get
+          - proposal.list
+          - proposal.update
+        pr:
+          - pr.create
+          - pr.update
+          - pr.get
+        git:
+          - git.clone
+          - git.push
+        skill:
+          - skill.register
+          - skill.get
+          - skill.list
+        court:
+          - court.submit_vote
+          - court.get_reviews
+        permission_visibility:   # from permissions-model
+          - permission.grant
+          - permission.revoke
+          - permission.list
+          - permission.check
+          - permission.snapshot
+          - permission.request
+          - visibility.set
+          - visibility.get
+          - visibility.list
+      invariants:
+        - Only Store performs final merge after Court approval
+        - Enforces branch protection (no force-push, no direct merges by others)
+        - All relevant mutations append to tamper-evident Merkle audit log
+        - Permission grants + visibility policies gate sensitive operations
+
+  cross_component_invariants:
+    - No code change reaches the live registry without Court review + Store final merge
+    - Builder VMs have no merge rights and no direct host FS access
+    - Discovery (tool.list / tool.search / tool.registry.discover) is always filtered by current grants + visibility
+    - Every action is auditable
+    - MicroVMs cannot self-grant capabilities
+
+  recommended_usage_for_implementers: |
+    When generating code or extending the workflow:
+    1. Emit the exact command names listed above.
+    2. Wire audit.append for mutations.
+    3. Respect permission checks before sensitive actions.
+    4. Update this file + the component specs (builder-vm.md, store-vm.md) when adding new verbs.

--- a/docs/specs/sdlc-commands.yaml
+++ b/docs/specs/sdlc-commands.yaml
@@ -27,6 +27,7 @@ sdlc:
         - Modify Court reviews or approvals
         - Direct host filesystem access
         - Self-grant permissions
+        - proposal.create (must come from approved flow; never bypass)
       permissions_note: "Builder operations respect grants and visibility policies (see permissions-model.md)."
       audit: "All actions logged via Store audit.append"
 
@@ -67,6 +68,21 @@ sdlc:
         - Enforces branch protection (no force-push, no direct merges by others)
         - All relevant mutations append to tamper-evident Merkle audit log
         - Permission grants + visibility policies gate sensitive operations
+        - proposal.create is only callable by subjects with proper grant (host/CLI privileged or explicit autonomy grant); denied attempts return ERR_PERMISSION_DENIED and are audited
+
+    cli_host:
+      description: Host CLI (aegis) is privileged user/agent entry point. Routes via hub to Store for mutations.
+      can:
+        - skills propose "<description>"  # creates via proposal.create (Store surface)
+        - skills list
+        - skills status
+        - court decisions ...
+        - audit log
+      cannot:
+        - direct Store mutations without hub
+        - bypass permission checks
+      mapping:
+        "aegis skills propose": proposal.create   # natural lang desc -> minimal payload with id,title,description,type=skill,proposed_via=cli
 
   cross_component_invariants:
     - No code change reaches the live registry without Court review + Store final merge
@@ -74,6 +90,7 @@ sdlc:
     - Discovery (tool.list / tool.search / tool.registry.discover) is always filtered by current grants + visibility
     - Every action is auditable
     - MicroVMs cannot self-grant capabilities
+    - CLI "skills propose" succeeds for host subjects; low-priv (microVM/agent) receives ERR_PERMISSION_DENIED + audit record
 
   recommended_usage_for_implementers: |
     When generating code or extending the workflow:
@@ -81,3 +98,13 @@ sdlc:
     2. Wire audit.append for mutations.
     3. Respect permission checks before sensitive actions.
     4. Update this file + the component specs (builder-vm.md, store-vm.md) when adding new verbs.
+    5. For proposal creation, always go through Store's proposal.create (CLI uses internal hub send or /api/proposals which delegates).
+
+  cli_verbs_added:
+    - verb: "skills propose <description>"
+      owner: cli_host (privileged) -> store_vm
+      payload_minimal: { id: "prop-<nano>", type: "skill", title: <derived>, description: <input>, proposed_via: "cli" }
+      response_on_success: { success: true, proposal_id: "..." }
+      error: "ERR_PERMISSION_DENIED: ..." (for missing grant)
+      court_trigger: "Store sends scribe.notify_review on successful create (existing path)"
+      notes: "First impl wires only propose creation + routing + authz + audit. Full SDLC (Builder/Court vote/merge) unchanged."

--- a/docs/specs/store-vm.md
+++ b/docs/specs/store-vm.md
@@ -74,7 +74,7 @@ The Store VM acts as the central, trusted authority for both structured data and
 The Store VM is the single source of truth for persistent timers, autonomy grants, and background work expiration.
 
 ### Chat Session Registry (Web Portal)
-The Store VM owns durable web-portal chat session records (id, title, timestamps, message thread snapshots). The Web Portal forwards `sessions.*` bridge actions here; live chat turns flow through the agent chat system (`chat.message`, not the Host Daemon).
+The Store VM owns durable web-portal chat session records (id, title, timestamps, message thread snapshots). The Web Portal forwards `sessions.*` bridge actions here; live chat turns flow through the agent chat system (`chat.message` — not the Host Daemon).
 
 - `sessions.list` — Session summaries for the chat sidebar
 - `sessions.create` — Create a new session

--- a/docs/specs/store-vm.md
+++ b/docs/specs/store-vm.md
@@ -1,11 +1,20 @@
 # Store VM Specification
 
 **Status:** Draft  
-**Last Updated:** May 2026 (Phase 2 timer/grant responsibilities added)
+**Last Updated:** June 2026 (Phase 2 timer/grant responsibilities added)
 
 ## Purpose
 
 The Store VM serves as both the **persistent data store** and the **trusted git remote** for all skills.
+
+## For Implementers
+
+The Store VM is the single source of truth and enforcement point for proposals, git state, PRs, audit, and skill registry. When implementing or extending:
+- All mutations to git, PRs, proposals, or grants must go through Store commands.
+- Enforce branch protection and Court-only final merge.
+- Maintain the tamper-evident Merkle audit log on every relevant action.
+- Integrate permission grants and visibility (permissions-model.md) for proposal, Court, and Builder-related capabilities.
+- Expose the documented command surfaces cleanly over the signed vsock API.
 
 ## Responsibility Boundaries
 
@@ -65,7 +74,7 @@ The Store VM acts as the central, trusted authority for both structured data and
 The Store VM is the single source of truth for persistent timers, autonomy grants, and background work expiration.
 
 ### Chat Session Registry (Web Portal)
-The Store VM owns durable web-portal chat session records (id, title, timestamps, message thread snapshots). The Web Portal forwards `sessions.*` bridge actions here; live chat turns flow through the agent chat system (`chat.message`), not the Host Daemon.
+The Store VM owns durable web-portal chat session records (id, title, timestamps, message thread snapshots). The Web Portal forwards `sessions.*` bridge actions here; live chat turns flow through the agent chat system (`chat.message`, not the Host Daemon).
 
 - `sessions.list` — Session summaries for the chat sidebar
 - `sessions.create` — Create a new session
@@ -94,6 +103,7 @@ The Store VM owns durable web-portal chat session records (id, title, timestamps
 - The Store VM enforces branch protection rules (no force push, no direct merges)
 - Only the Store VM can perform the final merge after Court approval
 - Pull Request reviews can only be submitted by Court personas
+- Permission and visibility checks (permissions-model.md) gate sensitive proposal, Court, and grant operations.
 
 ## Test Requirements
 
@@ -102,3 +112,5 @@ The Store VM owns durable web-portal chat session records (id, title, timestamps
 - Only the Store VM can execute the final merge of an approved PR
 - All git operations must be traceable to a specific proposal
 - A malicious Builder VM must not be able to delete history or force-push
+- Permission grants must be enforced before allowing proposal or Court-related commands.
+


### PR DESCRIPTION
## Summary

Implements the `aegis skills propose "<description>"` CLI command on the `docs/sdlc-implementers-ready` branch, routing through the internal hub to the Store VM's `proposal.create` surface with proper permission gating. Includes significant test hardening and verification improvements, plus integration of the SDLC workflow documentation.

### Changes

- **CLI / `cmd/aegis/main.go`**:
  - New `buildMinimalProposal(desc)` pure function for natural-language to minimal payload conversion.
  - New `skillsProposeJSONOK(out []byte)` single source of truth parser (requires both `success:true` **and** non-empty `proposal_id`).
  - Rewired `runSkillsPropose` to use `sendToComponentViaHub("store", "proposal.create", ...)` for real Store path (instead of portal fixture).
  - Improved flag handling, error surfacing (including `ERR_PERMISSION_DENIED`), and `--json` output.
  - Added `resetInternalHubClientsForTest` and socket-path awareness for test isolation.

- **Store / `cmd/store/main.go`**:
  - Extracted `canCreateProposal`, `handleProposalCreate`, `performProposalCreate`, and `appendAuditForStateChangeIfNeeded` for testability and single-orchestrator clarity.
  - Permission gating for `proposal.create` (privileged host/CLI sources allowed; low-priv/agent/builder sources require explicit grant in `grants.json`; denied attempts audited).
  - `proposal.create` now properly delegates to the orchestrator and triggers `scribe.notify_review` on success.

- **Tests**:
  - Comprehensive table-driven `TestSkillsProposeJSONOK` and `TestHandleProposalCreate`.
  - `TestCanCreateProposalHappyAndDenied`, `TestProposalCreatePermissionAndAudit`.
  - Hardened Journey 04 (real sudo-daemon + live hub poll + hard asserts via the new helper).
  - `TestRunSkillsProposeDrivesSendTo`, `TestProposalCreateRealStoreLoop` exercising shipped paths with temp hubs/stores.
  - Centralized cleanup, removal of force-fakes and loose string checks.

- **Docs**:
  - Added `docs/specs/sdlc-code-development-workflow.md` (core flow, invariants, "For Implementers" guidance, CLI entry point).
  - Added `docs/specs/sdlc-commands.yaml` (machine-readable command surfaces and invariants).
  - Updated `builder-vm.md`, `store-vm.md`, `additional-requirements-and-gaps.md` with For Implementers sections and cross-refs.
  - Minor ACL updates in `config/acls.yaml` for `proposal.*`.

No breaking changes to existing Court, Builder, or merge flows. The `skills propose` command is the first wired entry point for the documented SDLC proposal → Court path.

## Verification

- All unit, integration, and tagged tests pass (`go test ./cmd/aegis ./cmd/store ...`).
- Live `sudo -n ./bin/aegis` smoke + `make smoke` succeed with real proposes returning `success:true` + non-empty `proposal_id`.
- Permission denial paths exercised and audited.
- Fresh artifacts confirm side-effects (proposals.json, audit.json, scribe.notify_review).

This branch (docs + implementation) is now ready for review and merge.